### PR TITLE
feat(inbound): add 3-layer spam protection to SMTP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,21 @@ SMTP_ENABLED=false
 # Port for the inbound SMTP server (default 2525; use 25 in production with proper permissions)
 SMTP_PORT=2525
 
+# ── SMTP Spam Protection ──
+# All layers are enabled by default when the SMTP server is on.
+# Check connecting IPs against a DNSBL (DNS blackhole list)
+SMTP_DNSBL_ENABLED=true
+# DNSBL zone to query (Spamhaus ZEN combines SBL + XBL + PBL)
+SMTP_DNSBL_ZONE=zen.spamhaus.org
+# Reject mail to domains not registered in BunMail
+SMTP_RECIPIENT_VALIDATION=true
+# Per-IP connection rate limiting
+SMTP_RATE_LIMIT_ENABLED=true
+# Max connections per IP per window
+SMTP_RATE_LIMIT_MAX=10
+# Rate limit window in seconds
+SMTP_RATE_LIMIT_WINDOW=60
+
 # ── Dashboard ──
 # Password for the /dashboard web UI. Leave empty to disable the dashboard.
 DASHBOARD_PASSWORD=

--- a/BunMail-Plan.md
+++ b/BunMail-Plan.md
@@ -253,7 +253,7 @@ Priority: 10
 ```
 Type: TXT
 Host: @
-Value: v=spf1 a mx ip4:YOUR_SERVER_IP ~all
+Value: v=spf1 a mx ip4:YOUR_SERVER_IP -all
 ```
 
 ### DKIM Record

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ To ensure emails land in the inbox, not spam, you need all of the following DNS 
 
 | Record | Example Value | Purpose |
 |--------|---------------|---------|
-| **SPF** | `v=spf1 a mx ip4:YOUR_IP ~all` | Tells receiving servers which IPs are allowed to send email on behalf of your domain. Prevents spoofing. |
+| **SPF** | `v=spf1 a mx ip4:YOUR_IP -all` | Tells receiving servers which IPs are allowed to send email on behalf of your domain. Prevents spoofing. |
 | **DKIM** | 2048-bit RSA key (auto-generated) | Cryptographically signs outgoing emails so recipients can verify the message wasn't tampered with in transit. BunMail generates and manages DKIM keys automatically when you register a domain. |
 | **DMARC** | `v=DMARC1; p=quarantine; rua=mailto:postmaster@yourdomain.com` | Instructs receiving servers how to handle emails that fail SPF/DKIM checks (`none` = monitor, `quarantine` = mark as spam, `reject` = drop). The `rua` address receives aggregate reports. |
 | **MX** | `10 mail.yourdomain.com` | Points your domain's incoming mail to your server. Required even for outbound-only setups — many spam filters reject mail from domains without an MX record. The number (`10`) is priority (lower = preferred). |

--- a/docs/inbound.md
+++ b/docs/inbound.md
@@ -43,12 +43,50 @@ Table: `inbound_emails`
 
 In production, set `SMTP_PORT=25` and configure your domain's MX record to point to your server.
 
+## Spam Protection
+
+Three layers of protection run before any email is processed. All are enabled by default.
+
+### Layer 1 — DNSBL IP Check
+
+Checks the connecting IP against a DNS blackhole list (default: [Spamhaus ZEN](https://www.spamhaus.org/zen/)). Blacklisted IPs are rejected with SMTP 554 before they can send data.
+
+| Env Variable         | Default              | Description                     |
+|----------------------|----------------------|---------------------------------|
+| `SMTP_DNSBL_ENABLED` | `true`              | Enable/disable DNSBL checks     |
+| `SMTP_DNSBL_ZONE`    | `zen.spamhaus.org`  | DNSBL zone to query             |
+
+Private/loopback IPs and IPv6 addresses skip the DNSBL check.
+
+### Layer 2 — Connection Rate Limiting
+
+Per-IP sliding window rate limit on SMTP connections. Exceeding the limit returns SMTP 421 (temporary rejection).
+
+| Env Variable            | Default | Description                       |
+|-------------------------|---------|-----------------------------------|
+| `SMTP_RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting     |
+| `SMTP_RATE_LIMIT_MAX`    | `10`   | Max connections per IP per window |
+| `SMTP_RATE_LIMIT_WINDOW` | `60`   | Window size in seconds           |
+
+### Layer 3 — Recipient Domain Validation
+
+Rejects mail addressed to domains not registered in BunMail's Domains table. This prevents your server from being used as an open relay.
+
+| Env Variable                | Default | Description                             |
+|-----------------------------|---------|-----------------------------------------|
+| `SMTP_RECIPIENT_VALIDATION` | `true`  | Enable/disable recipient domain checks  |
+
+### Fail-Open Design
+
+All three layers fail open on errors (DNS timeout, DB unreachable). This means legitimate mail is never silently dropped due to transient failures.
+
 ## How It Works
 
-1. The SMTP server accepts incoming connections (no auth required for inbound)
-2. Each incoming message is parsed with `mailparser`
-3. The sender, recipient, subject, HTML, text, and raw message are stored in `inbound_emails`
-4. An `email.received` webhook event is fired to all subscribed webhooks
+1. Client connects → rate limit check (instant) → DNSBL check (DNS lookup)
+2. RCPT TO command → recipient domain validated against registered domains
+3. DATA command → message parsed with `mailparser`
+4. Sender, recipient, subject, HTML, text, and raw message stored in `inbound_emails`
+5. `email.received` webhook event fired to all subscribed webhooks
 
 ## Service Methods
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -103,7 +103,7 @@ Add these DNS records for `yourdomain.com` in your domain registrar (Cloudflare,
 
 | Type | Host | Value                                    |
 |------|------|------------------------------------------|
-| TXT  | `@`  | `v=spf1 a mx ip4:YOUR_SERVER_IP ~all`    |
+| TXT  | `@`  | `v=spf1 a mx ip4:YOUR_SERVER_IP -all`    |
 
 ### DMARC Record (tells receivers what to do with unauthenticated mail)
 
@@ -286,7 +286,7 @@ All three must be set correctly. Verify with:
 ```bash
 # SPF
 dig TXT yourdomain.com +short
-# Expected: "v=spf1 a mx ip4:YOUR_SERVER_IP ~all"
+# Expected: "v=spf1 a mx ip4:YOUR_SERVER_IP -all"
 
 # DKIM
 dig TXT bunmail._domainkey.yourdomain.com +short

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,23 @@ export const config = {
     port: parseInt(optionalEnv("SMTP_PORT", "2525"), 10),
     /** Set to "true" to enable the inbound SMTP server */
     enabled: optionalEnv("SMTP_ENABLED", "false") === "true",
+
+    /** Spam protection layers — all enabled by default when SMTP is on */
+    spamProtection: {
+      /** Check connecting IPs against a DNSBL (e.g. Spamhaus ZEN) */
+      dnsblEnabled: optionalEnv("SMTP_DNSBL_ENABLED", "true") === "true",
+      /** DNSBL zone to query (default: zen.spamhaus.org) */
+      dnsblZone: optionalEnv("SMTP_DNSBL_ZONE", "zen.spamhaus.org"),
+      /** Reject mail to domains not registered in BunMail */
+      recipientValidationEnabled:
+        optionalEnv("SMTP_RECIPIENT_VALIDATION", "true") === "true",
+      /** Per-IP SMTP connection rate limiting */
+      rateLimitEnabled: optionalEnv("SMTP_RATE_LIMIT_ENABLED", "true") === "true",
+      /** Max connections per IP per window */
+      rateLimitMax: parseInt(optionalEnv("SMTP_RATE_LIMIT_MAX", "10"), 10),
+      /** Rate limit window in seconds */
+      rateLimitWindowSec: parseInt(optionalEnv("SMTP_RATE_LIMIT_WINDOW", "60"), 10),
+    },
   },
 
   /** Password-protected web dashboard at /dashboard */

--- a/src/modules/domains/services/domain.service.ts
+++ b/src/modules/domains/services/domain.service.ts
@@ -115,6 +115,22 @@ export async function getDomainById(id: string): Promise<Domain | undefined> {
 }
 
 /**
+ * Checks whether a domain name is registered in BunMail.
+ * Used by inbound SMTP spam protection to reject mail to unknown domains.
+ *
+ * @param name - The domain name to check (e.g. "example.com")
+ * @returns true if the domain exists in the database
+ */
+export async function domainExistsByName(name: string): Promise<boolean> {
+  const [domain] = await db
+    .select({ id: domains.id })
+    .from(domains)
+    .where(eq(domains.name, name))
+    .limit(1);
+  return !!domain;
+}
+
+/**
  * Deletes a domain by its ID (hard delete).
  *
  * Removes the domain row entirely from the database.

--- a/src/modules/inbound/services/smtp-receiver.service.ts
+++ b/src/modules/inbound/services/smtp-receiver.service.ts
@@ -1,14 +1,99 @@
+import { resolve4 } from "dns/promises";
 import { SMTPServer } from "smtp-server";
 import { simpleParser } from "mailparser";
 import { db } from "../../../db/index.ts";
 import { inboundEmails } from "../models/inbound-email.schema.ts";
 import { generateId } from "../../../utils/id.ts";
 import { dispatchEvent } from "../../webhooks/services/webhook-dispatch.service.ts";
+import { domainExistsByName } from "../../domains/services/domain.service.ts";
 import { config } from "../../../config.ts";
 import { logger } from "../../../utils/logger.ts";
 
 /** Reference to the running SMTP server instance */
 let server: SMTPServer | null = null;
+
+/** Interval handle for rate limit map cleanup */
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+/* ─── Per-IP SMTP connection rate limiting ─── */
+
+/** Tracks connection count and window start per IP */
+interface SmtpRateLimitEntry {
+  /** Number of connections in the current window */
+  count: number;
+  /** Timestamp (ms) when the current window started */
+  windowStart: number;
+}
+
+/** In-memory map of IP → rate limit state */
+const rateLimitMap = new Map<string, SmtpRateLimitEntry>();
+
+/**
+ * Checks and increments the per-IP SMTP connection counter.
+ * Returns true if the IP has exceeded the configured limit.
+ *
+ * Uses a sliding window identical to the HTTP rate limiter pattern
+ * in src/middleware/rate-limit.ts.
+ *
+ * @param ip - The connecting client's IP address
+ */
+function isRateLimited(ip: string): boolean {
+  const { rateLimitMax, rateLimitWindowSec } = config.smtp.spamProtection;
+  const windowMs = rateLimitWindowSec * 1000;
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+
+  /** New IP or expired window — start fresh */
+  if (!entry || now - entry.windowStart >= windowMs) {
+    rateLimitMap.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+
+  entry.count += 1;
+  return entry.count > rateLimitMax;
+}
+
+/* ─── DNSBL (DNS-based blackhole list) check ─── */
+
+/**
+ * Checks an IPv4 address against a DNSBL zone (e.g. Spamhaus ZEN).
+ *
+ * Algorithm: reverse the IP octets → query `<reversed>.<zone>`.
+ * If the DNS lookup returns any A records, the IP is listed.
+ * A NOTFOUND / timeout means the IP is clean.
+ *
+ * Skips private, loopback, and IPv6 addresses (not indexed by most DNSBLs).
+ *
+ * @param ip   - The connecting client's IP address
+ * @param zone - The DNSBL zone to query (e.g. "zen.spamhaus.org")
+ * @returns true if the IP is blacklisted
+ */
+async function isBlacklistedIp(ip: string, zone: string): Promise<boolean> {
+  /** Skip private / loopback IPs — they're never in DNSBLs */
+  if (
+    ip === "127.0.0.1" ||
+    ip === "::1" ||
+    ip.startsWith("10.") ||
+    ip.startsWith("192.168.") ||
+    ip.startsWith("172.")
+  ) {
+    return false;
+  }
+
+  /** IPv6 not supported by most DNSBLs — skip */
+  if (ip.includes(":")) return false;
+
+  const reversed = ip.split(".").reverse().join(".");
+  const query = `${reversed}.${zone}`;
+
+  try {
+    const results = await resolve4(query);
+    return results.length > 0;
+  } catch {
+    /** NOTFOUND, TIMEOUT, etc. — IP is not listed (fail open) */
+    return false;
+  }
+}
 
 /**
  * Starts the inbound SMTP server.
@@ -17,16 +102,111 @@ let server: SMTPServer | null = null;
  * incoming emails. Each message is parsed, stored in the database,
  * and forwarded to webhooks as an `email.received` event.
  *
- * Uses permissive auth (accepts all senders) — suitable for
- * receiving inbound mail on a domain's MX record.
+ * Three spam protection layers run before message processing:
+ * 1. Per-IP rate limiting (in-memory, instant)
+ * 2. DNSBL IP check (async DNS lookup against Spamhaus ZEN)
+ * 3. Recipient domain validation (DB check against registered domains)
  */
 export function start(): void {
   const port = config.smtp.port;
+  const { spamProtection } = config.smtp;
 
   server = new SMTPServer({
     secure: false,
     authOptional: true,
     disabledCommands: ["STARTTLS", "AUTH"],
+
+    /**
+     * Called when a client connects.
+     * Runs rate limiting (instant) and DNSBL check (async DNS)
+     * to reject bad IPs before they can send any data.
+     */
+    onConnect(session, callback) {
+      const ip = session.remoteAddress;
+
+      /** Layer 2: Per-IP rate limiting (runs first — instant, no I/O) */
+      if (spamProtection.rateLimitEnabled && isRateLimited(ip)) {
+        logger.warn("SMTP connection rate limited", { ip });
+        const err = new Error("Too many connections, try again later") as Error & {
+          responseCode: number;
+        };
+        err.responseCode = 421;
+        return callback(err);
+      }
+
+      /** Layer 1: DNSBL check (async DNS lookup) */
+      if (!spamProtection.dnsblEnabled) {
+        return callback();
+      }
+
+      isBlacklistedIp(ip, spamProtection.dnsblZone)
+        .then((listed) => {
+          if (listed) {
+            logger.warn("SMTP connection rejected — IP blacklisted", { ip });
+            const err = new Error(
+              "Connection rejected — your IP is blacklisted",
+            ) as Error & {
+              responseCode: number;
+            };
+            err.responseCode = 554;
+            return callback(err);
+          }
+          callback();
+        })
+        .catch(() => {
+          /** DNS lookup failed — allow connection (fail open) */
+          callback();
+        });
+    },
+
+    /**
+     * Called for each RCPT TO command.
+     * Validates that the recipient's domain is registered in BunMail.
+     * Rejects mail to unknown domains with SMTP 550.
+     */
+    onRcptTo(address, session, callback) {
+      if (!spamProtection.recipientValidationEnabled) {
+        return callback();
+      }
+
+      const recipientAddress = address.address;
+      const domain = recipientAddress.split("@")[1]?.toLowerCase();
+
+      if (!domain) {
+        logger.warn("SMTP RCPT TO rejected — invalid address", {
+          address: recipientAddress,
+        });
+        const err = new Error("Invalid recipient address") as Error & {
+          responseCode: number;
+        };
+        err.responseCode = 550;
+        return callback(err);
+      }
+
+      domainExistsByName(domain)
+        .then((exists) => {
+          if (!exists) {
+            logger.warn("SMTP RCPT TO rejected — unknown domain", {
+              address: recipientAddress,
+              domain,
+              ip: session.remoteAddress,
+            });
+            const err = new Error(
+              `Recipient domain "${domain}" is not handled here`,
+            ) as Error & { responseCode: number };
+            err.responseCode = 550;
+            return callback(err);
+          }
+          callback();
+        })
+        .catch((error) => {
+          /** DB query failed — allow through (fail open) */
+          logger.error("Domain lookup failed during RCPT TO check", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          callback();
+        });
+    },
 
     /**
      * Called for each incoming email.
@@ -99,6 +279,15 @@ export function start(): void {
 
   server.listen(port, () => {
     logger.info("Inbound SMTP server started", { port });
+
+    /** Log which protection layers are active */
+    logger.info("SMTP spam protection", {
+      dnsbl: spamProtection.dnsblEnabled ? spamProtection.dnsblZone : "disabled",
+      recipientValidation: spamProtection.recipientValidationEnabled,
+      rateLimit: spamProtection.rateLimitEnabled
+        ? `${spamProtection.rateLimitMax}/${spamProtection.rateLimitWindowSec}s`
+        : "disabled",
+    });
   });
 
   server.on("error", (err) => {
@@ -106,6 +295,20 @@ export function start(): void {
       error: err instanceof Error ? err.message : String(err),
     });
   });
+
+  /** Periodic cleanup of expired rate limit entries (every 5 minutes) */
+  cleanupInterval = setInterval(
+    () => {
+      const now = Date.now();
+      const windowMs = spamProtection.rateLimitWindowSec * 1000;
+      for (const [ip, entry] of rateLimitMap) {
+        if (now - entry.windowStart >= windowMs) {
+          rateLimitMap.delete(ip);
+        }
+      }
+    },
+    5 * 60 * 1000,
+  );
 }
 
 /**
@@ -113,6 +316,11 @@ export function start(): void {
  * Called during application shutdown (SIGINT / SIGTERM).
  */
 export function stop(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
+
   if (server) {
     server.close(() => {
       logger.info("Inbound SMTP server stopped");

--- a/src/pages/routes/domain-detail.tsx
+++ b/src/pages/routes/domain-detail.tsx
@@ -64,7 +64,7 @@ export function DomainDetailPage({ domain, flash }: DomainDetailPageProps) {
           <DnsRecordEntry
             type="TXT"
             host={domain.name}
-            value={`v=spf1 a mx ip4:<YOUR_SERVER_IP> ~all`}
+            value={`v=spf1 a mx ip4:<YOUR_SERVER_IP> -all`}
             label="SPF Record"
           />
           {dkimRecord && (


### PR DESCRIPTION
## Summary

- Add DNSBL IP check (Spamhaus ZEN) to reject blacklisted IPs on connect
- Add per-IP connection rate limiting (10/min default) to throttle abusive senders
- Add recipient domain validation to reject mail to unregistered domains

All layers are enabled by default and fail open on errors (DNS timeout, DB unreachable → allow through).

## Changes

- `src/config.ts` — 6 new env vars under `smtp.spamProtection`
- `src/modules/domains/services/domain.service.ts` — new `domainExistsByName()`
- `src/modules/inbound/services/smtp-receiver.service.ts` — `onConnect` + `onRcptTo` hooks, DNSBL helper, rate limit map + cleanup
- `.env.example` — document new env vars
- `docs/inbound.md` — spam protection documentation

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 124 tests pass
- [x] Deploy and verify spam bots are rejected in logs
- [x] Verify legitimate mail to registered domains still accepted