### PR TITLE
fix: validate LOG_LEVEL at config load (#39)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,25 @@ function optionalEnv(key: string, fallback: string): string {
   return process.env[key] ?? fallback;
 }
 
+/** Allowed log-level values — must match the logger implementation. */
+const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+/**
+ * Reads `LOG_LEVEL` and validates it against the allowed union.
+ * Throws at startup with a clear message on a typo so the operator
+ * notices immediately rather than silently getting `info`-equivalent behaviour.
+ */
+function readLogLevel(): LogLevel {
+  const raw = optionalEnv("LOG_LEVEL", "info");
+  if (!(LOG_LEVELS as readonly string[]).includes(raw)) {
+    throw new Error(
+      `[config] Invalid LOG_LEVEL "${raw}" — must be one of: ${LOG_LEVELS.join(", ")}`,
+    );
+  }
+  return raw as LogLevel;
+}
+
 /**
  * Central application configuration.
  *
@@ -83,8 +102,8 @@ export const config = {
     sessionSecret: optionalEnv("SESSION_SECRET", randomUUID()),
   },
 
-  /** Log level: debug | info | warn | error */
-  logLevel: optionalEnv("LOG_LEVEL", "info"),
+  /** Log level: debug | info | warn | error — validated at startup */
+  logLevel: readLogLevel(),
 
   /** Trash / soft-delete retention */
   trash: {


### PR DESCRIPTION
## Summary

`config.logLevel` was typed `string` and accepted any value at startup. A typo like `LOG_LEVEL=infoo` silently behaved as the logger's default — operator never noticed.

## Changes

- New `LOG_LEVELS` const array + exported `LogLevel` union type
- New `readLogLevel()` helper that throws `[config] Invalid LOG_LEVEL "<value>" — must be one of: debug, info, warn, error` on bad input
- `config.logLevel` now uses the validated value

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 138/138 tests pass
- [x] `bun run lint` clean
- [x] Manual: `LOG_LEVEL=garbage bun src/index.ts` throws with the new error
- [ ] CI green

Closes #39

Generated with [Claude Code](https://claude.com/claude-code)