### PR TITLE
fix: cap email html/text payloads at 5MB (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Cap on outbound email body size — `html` and `text` fields are now limited to 5 MB each via DTO validation; oversize payloads return `422`. (#26)
+- Periodic cleanup for the in-memory HTTP rate-limit map; expired entries are pruned every 5 minutes so the map can't grow unbounded under high cardinality. (#22)
+
+### Changed
+
+- `LOG_LEVEL` is now validated at config load — invalid values fail loudly with a clear error instead of silently behaving like the default. (#39)
+
 ## [0.3.0] - 2026-04-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ When adding a data model:
 - Keep docs concise: update only what changed.
 - Every module should have its own `docs/<module-name>.md` documenting schema, types, service methods, and module layout.
 - Every module's endpoints must be listed in `docs/api.md`.
+- **Every PR must update the relevant `.md` docs in the same commit** — `CHANGELOG.md` (always, under `[Unreleased]`), and any of `README.md` / `ARCHITECTURE.md` / `docs/api.md` / `docs/<module>.md` whose content the PR makes outdated. Mention the doc updates in the PR description's "Changes" section. Don't merge a PR that adds/removes/changes a public API surface or env var without the matching doc edit.
 - **Update `CHANGELOG.md` on every release.** When `bumpp` cuts a new version, add a corresponding entry summarizing user-facing changes (added / changed / fixed) under the new version heading, following Keep a Changelog format.
 
 ## Collaboration

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,12 +61,14 @@ Queue a new email for delivery. Supports direct content or template-based sendin
 | `from`       | string | Yes      | Sender email address                         |
 | `to`         | string | Yes      | Recipient email address                      |
 | `subject`    | string | *        | Subject line (required when not using template) |
-| `html`       | string | No       | HTML body                                    |
-| `text`       | string | No       | Plain text body                              |
+| `html`       | string | No       | HTML body (max 5 MB)                         |
+| `text`       | string | No       | Plain text body (max 5 MB)                   |
 | `cc`         | string | No       | Comma-separated CC recipients                |
 | `bcc`        | string | No       | Comma-separated BCC recipients               |
 | `templateId` | string | No       | Template ID (overrides subject/html/text)    |
 | `variables`  | object | No       | Key-value pairs for template rendering       |
+
+Oversize bodies return `422 Unprocessable Entity` from the validation layer.
 
 **Response:**
 

--- a/src/modules/emails/dtos/send-email.dto.ts
+++ b/src/modules/emails/dtos/send-email.dto.ts
@@ -1,6 +1,14 @@
 import { t } from "elysia";
 
 /**
+ * Maximum allowed length for the HTML and text bodies of an outbound email,
+ * in characters. Matches typical SaaS provider limits (SendGrid: 30MB total,
+ * Resend: 5MB) — we cap each body at 5 MB so a misbehaving caller can't OOM
+ * the queue or the SMTP transport.
+ */
+export const MAX_BODY_LENGTH = 5 * 1024 * 1024;
+
+/**
  * Validation schema for POST /api/v1/emails/send request body.
  *
  * Supports two modes:
@@ -16,8 +24,8 @@ export const sendEmailDto = t.Object({
 
   /** Required when not using a template */
   subject: t.Optional(t.String({ maxLength: 500 })),
-  html: t.Optional(t.String()),
-  text: t.Optional(t.String()),
+  html: t.Optional(t.String({ maxLength: MAX_BODY_LENGTH })),
+  text: t.Optional(t.String({ maxLength: MAX_BODY_LENGTH })),
 
   /** Template-based sending — takes precedence over inline content when set */
   templateId: t.Optional(t.String()),

--- a/test/e2e/emails-api.test.ts
+++ b/test/e2e/emails-api.test.ts
@@ -202,6 +202,29 @@ describe("Emails API E2E", () => {
 
       expect(response.status).toBe(422);
     });
+
+    test("returns 422 when html body exceeds the 5MB cap", async () => {
+      /** 6 MB of "a" — comfortably over the 5 MB DTO limit */
+      const oversizeHtml = "a".repeat(6 * 1024 * 1024);
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/emails/send", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test_key",
+          },
+          body: JSON.stringify({
+            from: "hello@example.com",
+            to: "user@test.com",
+            subject: "Big",
+            html: oversizeHtml,
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(422);
+    });
   });
 
   describe("GET /api/v1/emails", () => {


### PR DESCRIPTION
## Summary

The send-email DTO only constrained `subject`. A misbehaving caller could push a 50MB body through the validator → it would sit in the queue, get loaded into memory on each retry, likely crash the SMTP transport.

## Changes

- `src/modules/emails/dtos/send-email.dto.ts` — exported `MAX_BODY_LENGTH = 5MB`, applied to `html` and `text` fields
- New e2e case: oversize body returns `422`
- `docs/api.md` — documented the 5 MB cap and the `422` response
- `CLAUDE.md` — added: every PR must update the relevant `.md` docs in the same commit
- `CHANGELOG.md` — opened `[Unreleased]` section covering #22, #26, #39

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 80 unit + 62 e2e = 142 tests pass (1 new)
- [x] `bun run lint` clean
- [x] CI green

Closes #26
Generated with [Claude Code](https://claude.com/claude-code)