### PR TITLE
fix: enable opportunistic STARTTLS on outbound delivery (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cap on outbound email body size — `html` and `text` fields are now limited to 5 MB each via DTO validation; oversize payloads return `422`. (#26)
 - Periodic cleanup for the in-memory HTTP rate-limit map; expired entries are pruned every 5 minutes so the map can't grow unbounded under high cardinality. (#22)
+- Opportunistic STARTTLS on outbound delivery — every recipient MX that advertises STARTTLS is now upgraded to TLS. Documented in `SECURITY.md`. (#21)
 
 ### Changed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,3 +44,9 @@ The following are in scope:
 - Rotate API keys periodically
 - Keep BunMail and its dependencies up to date
 - Use a firewall to restrict SMTP port access (2525)
+
+## Outbound TLS
+
+BunMail enables **opportunistic STARTTLS** when delivering to recipient MX servers — every connection that advertises STARTTLS will be upgraded to TLS, and only legacy receivers that don't speak TLS at all stay in plaintext. Cipher / cert validation is intentionally relaxed (`rejectUnauthorized: false`) because MTA-to-MTA delivery routinely encounters self-signed and expired certificates; refusing them would mean dropping legitimate mail.
+
+If you need to **require** TLS for specific recipient domains (e.g. internal compliance), that's tracked in [#42](https://github.com/mohamedboukari/bunmail/issues/42). Per-message TLS observability metrics (cipher used, validation state) are tracked in [#37](https://github.com/mohamedboukari/bunmail/issues/37).

--- a/src/modules/emails/services/mailer.service.ts
+++ b/src/modules/emails/services/mailer.service.ts
@@ -68,11 +68,20 @@ export async function sendMail(options: {
    * Create a transport that connects directly to the recipient's MX
    * server on port 25. A new transport per message ensures we always
    * connect to the correct MX for the recipient's domain.
+   *
+   * `opportunisticTLS` makes Nodemailer issue STARTTLS whenever the
+   * receiving server advertises support for it, but still allows
+   * delivery in the clear when the MX doesn't speak TLS at all (legacy
+   * receivers). Cipher / cert validation is intentionally relaxed
+   * (`rejectUnauthorized: false`) — MTA-to-MTA delivery routinely
+   * encounters self-signed and expired certs, and refusing them would
+   * mean dropping legitimate mail. Tracked in #42 for stricter handling.
    */
   const transport = nodemailer.createTransport({
     host: mxHost,
     port: 25,
     secure: false,
+    opportunisticTLS: true,
     name: config.mail.hostname,
     tls: {
       rejectUnauthorized: false,


### PR DESCRIPTION
## Summary

Outbound mail wasn't issuing STARTTLS even when the recipient MX advertised it — mail went plaintext on connections that should have been encrypted, hurting deliverability with Gmail/Outlook/Yahoo.

## Changes

- `src/modules/emails/services/mailer.service.ts` — added `opportunisticTLS: true` to the per-message transport
- `SECURITY.md` — new "Outbound TLS" section explaining the opportunistic upgrade and the trade-off on `rejectUnauthorized: false`; references #42 and #37 for the longer-term hardening
- `CHANGELOG.md` — `[Unreleased]` updated

### Out of scope (separate issues)

- Per-domain `requireTLS` enforcement → tracked in #42
- Per-message TLS metrics (cipher, validation status) → tracked in #37
- Per-message "fell back to plaintext" warning needs Nodemailer connection-level hooks; deferred to #37 where it fits the metrics work.

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 80 unit + 62 e2e = 142 tests pass
- [x] `bun run lint` clean
- [ ] CI green

Closes #21

 Generated with [Claude Code](https://claude.com/claude-code)