### PR TITLE
fix: throttle api_keys.last_used_at writes (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `LOG_LEVEL` is now validated at config load — invalid values fail loudly with a clear error instead of silently behaving like the default. (#39)
 - Auth middleware no longer hashes the bearer token or queries `api_keys` twice per request. The lookup result is cached on the `Request` (via a `WeakMap`) and reused by `resolve`, halving DB load on the auth path. (#27)
+- `api_keys.last_used_at` writes are now throttled to once every 60 s per key. A hot caller no longer fires one `UPDATE` per request; the timestamp can lag by up to the throttle window. (#28)
 
 ## [0.3.0] - 2026-04-26
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -19,6 +19,18 @@ interface AuthenticatedKey {
 const authCache = new WeakMap<Request, AuthenticatedKey>();
 
 /**
+ * Minimum interval between `last_used_at` writes for the same API key.
+ * Without this throttle a hot key under sustained load would fire one
+ * `UPDATE` per request — pure write amplification with no observable
+ * benefit (the timestamp is only used for "stale key" UX, not security).
+ *
+ * Trade-off: `last_used_at` can lag by up to this window. 60 seconds
+ * is well below any human-relevant precision.
+ */
+const LAST_USED_THROTTLE_MS = 60_000;
+const lastUsedWriteAt = new Map<string, number>();
+
+/**
  * Auth middleware — validates Bearer tokens on every request.
  *
  * Flow:
@@ -113,21 +125,28 @@ export const authMiddleware = new Elysia({ name: "auth-middleware" })
     }
 
     /**
-     * Update last_used_at timestamp — fire-and-forget.
-     * Non-critical and shouldn't slow down the request. Errors logged.
+     * Update `last_used_at` — throttled per key so a hot caller doesn't
+     * fire one `UPDATE` per request. The previous-write timestamp lives
+     * in `lastUsedWriteAt`; we only enqueue a new write when the
+     * throttle window has elapsed. Fire-and-forget; errors logged.
      */
-    db.update(apiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(apiKeys.id, cached.id))
-      .then(() => {
-        logger.debug("Updated last_used_at", { apiKeyId: cached.id });
-      })
-      .catch((error: unknown) => {
-        logger.error("Failed to update last_used_at", {
-          apiKeyId: cached.id,
-          error: error instanceof Error ? error.message : String(error),
+    const now = Date.now();
+    const lastWrite = lastUsedWriteAt.get(cached.id) ?? 0;
+    if (now - lastWrite >= LAST_USED_THROTTLE_MS) {
+      lastUsedWriteAt.set(cached.id, now);
+      db.update(apiKeys)
+        .set({ lastUsedAt: new Date(now) })
+        .where(eq(apiKeys.id, cached.id))
+        .then(() => {
+          logger.debug("Updated last_used_at", { apiKeyId: cached.id });
+        })
+        .catch((error: unknown) => {
+          logger.error("Failed to update last_used_at", {
+            apiKeyId: cached.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+    }
 
     logger.debug("Auth successful", { apiKeyId: cached.id, apiKeyName: cached.name });
 


### PR DESCRIPTION
## Summary

Every authenticated request fired `UPDATE api_keys SET last_used_at = NOW()`. On a hot key under load that's one write per request — pure write amplification, no observable benefit.

## Changes

- `src/middleware/auth.ts` — module-level `Map<apiKeyId, lastWrittenAtMs>`. The `UPDATE` only fires when 60 s have elapsed since the last write for that key.
- `CHANGELOG.md` — `[Unreleased]` entry under Changed.

## Trade-off (documented inline)

The `last_used_at` timestamp can now lag by up to 60 s. Since this column is purely UX ("when was this key last used?") and never feeds security decisions, the precision drop is acceptable.

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 80 unit + 62 e2e = 142 tests pass
- [x] `bun run lint` clean
- [x] CI green

Closes #28

Generated with [Claude Code](https://claude.com/claude-code)