### PR TITLE
fix: extend webhook event union with email.received + email.complained (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cap on outbound email body size — `html` and `text` fields are now limited to 5 MB each via DTO validation; oversize payloads return `422`. (#26)
 - Periodic cleanup for the in-memory HTTP rate-limit map; expired entries are pruned every 5 minutes so the map can't grow unbounded under high cardinality. (#22)
 - Opportunistic STARTTLS on outbound delivery — every recipient MX that advertises STARTTLS is now upgraded to TLS. Documented in `SECURITY.md`. (#21)
+- Webhook event union now includes `email.received` (fired by the inbound SMTP path) and `email.complained` (reserved for FBL processing). (#31)
+
+### Fixed
+
+- The inbound SMTP receiver no longer casts `"email.received"` to `"email.queued"` to silence the type checker — the event name is properly typed and accepted by the webhook DTO. (#31)
 
 ### Changed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,7 +285,7 @@ Register a new webhook endpoint.
 | `url`    | string   | Yes      | HTTPS endpoint URL                                 |
 | `events` | string[] | Yes      | Events to subscribe to (min 1)                     |
 
-Allowed events: `email.queued`, `email.sent`, `email.failed`, `email.bounced`
+Allowed events: `email.queued`, `email.sent`, `email.failed`, `email.bounced`, `email.complained`, `email.received`
 
 **Response includes `secret`** — shown once, used for HMAC signature verification.
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -37,12 +37,14 @@ Table: `webhooks`
 
 ## Event Types
 
-| Event           | Fired when                          |
-|-----------------|-------------------------------------|
-| `email.queued`  | An email is inserted into the queue |
-| `email.sent`    | An email is successfully delivered  |
-| `email.failed`  | An email permanently fails (3 attempts) |
-| `email.bounced` | A bounce notification is received   |
+| Event              | Fired when                                                     |
+|--------------------|----------------------------------------------------------------|
+| `email.queued`     | An email is inserted into the queue                            |
+| `email.sent`       | An email is successfully delivered                             |
+| `email.failed`     | An email permanently fails (3 attempts)                        |
+| `email.bounced`    | A bounce notification is received (DSN parsing — see [#24](https://github.com/mohamedboukari/bunmail/issues/24)) |
+| `email.complained` | A recipient marked the message as spam (FBL — see [#24](https://github.com/mohamedboukari/bunmail/issues/24)) |
+| `email.received`   | An inbound email is accepted by the SMTP receiver              |
 
 ## Webhook Payload
 

--- a/src/modules/inbound/services/smtp-receiver.service.ts
+++ b/src/modules/inbound/services/smtp-receiver.service.ts
@@ -257,7 +257,7 @@ export function start(): void {
           });
 
           /** Fire webhook event asynchronously (fire-and-forget) */
-          dispatchEvent("email.received" as "email.queued", {
+          dispatchEvent("email.received", {
             inboundEmailId: id,
             from,
             to,

--- a/src/modules/webhooks/dtos/create-webhook.dto.ts
+++ b/src/modules/webhooks/dtos/create-webhook.dto.ts
@@ -5,13 +5,19 @@ export const createWebhookDto = t.Object({
   /** HTTPS endpoint URL */
   url: t.String({ format: "uri" }),
 
-  /** Event types to subscribe to */
+  /**
+   * Event types to subscribe to. Must mirror the `WebhookEventType` union
+   * in `types/webhook.types.ts` — TypeBox literals can't be derived from
+   * a TypeScript type, so the two are kept in sync manually.
+   */
   events: t.Array(
     t.Union([
       t.Literal("email.queued"),
       t.Literal("email.sent"),
       t.Literal("email.failed"),
       t.Literal("email.bounced"),
+      t.Literal("email.complained"),
+      t.Literal("email.received"),
     ]),
     { minItems: 1 },
   ),

--- a/src/modules/webhooks/types/webhook.types.ts
+++ b/src/modules/webhooks/types/webhook.types.ts
@@ -10,9 +10,16 @@ export interface CreateWebhookInput {
   events: string[];
 }
 
-/** All webhook event types BunMail can fire */
+/**
+ * All webhook event types BunMail can fire. When adding a new value here,
+ * also extend the literal union in `dtos/create-webhook.dto.ts` — the DTO
+ * uses hardcoded literals (TypeBox can't introspect a TypeScript union),
+ * so the two locations have to be kept in sync manually.
+ */
 export type WebhookEventType =
   | "email.queued"
   | "email.sent"
   | "email.failed"
-  | "email.bounced";
+  | "email.bounced"
+  | "email.complained"
+  | "email.received";


### PR DESCRIPTION
## Summary

The SMTP inbound path fired `dispatchEvent("email.received" as "email.queued", ...)` — the cast was a lie because the `WebhookEventType` union didn't include that value. Subscribers seeing `"email.received"` over the wire would have been confused.

## Changes

- `src/modules/webhooks/types/webhook.types.ts` — added `email.received` and `email.complained` to the union; cross-reference comment to the DTO
- `src/modules/webhooks/dtos/create-webhook.dto.ts` — mirrored the new literals (TypeBox can't introspect the TS union); cross-reference comment
- `src/modules/inbound/services/smtp-receiver.service.ts` — dropped the `as "email.queued"` cast
- `docs/webhooks.md` + `docs/api.md` — documented the two new event types
- `CHANGELOG.md` — `[Unreleased]` updated under Added + Fixed

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 80 unit + 62 e2e = 142 tests pass
- [x] `bun run lint` clean
- [x] CI green

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)