### PR TITLE
fix: refuse to start in production with empty DASHBOARD_PASSWORD (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The inbound SMTP receiver no longer casts `"email.received"` to `"email.queued"` to silence the type checker — the event name is properly typed and accepted by the webhook DTO. (#31)
 
+### Security
+
+- BunMail refuses to start in production with an empty `DASHBOARD_PASSWORD`. The dashboard mounts unscoped read/write routes across all API keys, so a deployment with `BUNMAIL_ENV=production` and no password is rejected with a clear error at config load. Development behaviour is unchanged (empty password disables the dashboard). (#19)
+
 ### Changed
 
 - `LOG_LEVEL` is now validated at config load — invalid values fail loudly with a clear error instead of silently behaving like the default. (#39)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ The following are in scope:
 
 ## Security Best Practices for Self-Hosters
 
-- Always set a strong `DASHBOARD_PASSWORD`
+- Always set a strong `DASHBOARD_PASSWORD` — BunMail refuses to boot in production with an empty value (`BUNMAIL_ENV=production` + empty `DASHBOARD_PASSWORD` throws at startup) because the dashboard reads/writes across all API keys.
 - Never expose the dashboard publicly without a reverse proxy + TLS
 - Rotate API keys periodically
 - Keep BunMail and its dependencies up to date

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,25 @@ function readLogLevel(): LogLevel {
 }
 
 /**
+ * Reads `DASHBOARD_PASSWORD` and refuses to boot in production with an empty
+ * value. The dashboard exposes unscoped read/write across all API keys, so a
+ * production instance with no password is a tenant-isolation incident waiting
+ * to happen. In development the empty default still disables the dashboard.
+ */
+function readDashboardPassword(env: "development" | "production"): string {
+  const password = optionalEnv("DASHBOARD_PASSWORD", "");
+  if (env === "production" && password === "") {
+    throw new Error(
+      "[config] DASHBOARD_PASSWORD must be set when BUNMAIL_ENV=production.\n" +
+        "  → The dashboard reads/writes across all API keys; an empty\n" +
+        "    password leaves it disabled but the routes still mount. Set a\n" +
+        "    strong value in your .env (or unset BUNMAIL_ENV for dev).",
+    );
+  }
+  return password;
+}
+
+/**
  * Central application configuration.
  *
  * Every setting is read from environment variables at import time.
@@ -96,8 +115,13 @@ export const config = {
 
   /** Password-protected web dashboard at /dashboard */
   dashboard: {
-    /** Empty = dashboard disabled */
-    password: optionalEnv("DASHBOARD_PASSWORD", ""),
+    /**
+     * Empty = dashboard disabled. In production an empty password causes
+     * `readDashboardPassword` to throw; see the helper for the rationale.
+     */
+    password: readDashboardPassword(
+      optionalEnv("BUNMAIL_ENV", "development") as "development" | "production",
+    ),
     /** HMAC secret for session cookies; random UUID by default (resets on restart) */
     sessionSecret: optionalEnv("SESSION_SECRET", randomUUID()),
   },


### PR DESCRIPTION
## Summary

The dashboard mounts unscoped read/write routes across all API keys. With an empty `DASHBOARD_PASSWORD` the password check short-circuits to "disabled" so the routes are inaccessible — but a deployment that drifts away from the empty default (or removes it from `.env`) could expose every tenant's data silently.

## Changes

- `src/config.ts` — new `readDashboardPassword(env)` that throws at startup when `BUNMAIL_ENV=production` && password is empty. Dev behaviour is unchanged.
- `SECURITY.md` — documented the new guard
- `CHANGELOG.md` — `[Unreleased]` Security section

### Already in place (mentioned in the issue's AC)

- Route-level session guard already exists at `src/pages/pages.plugin.tsx:218-239` and redirects unauthenticated requests to `/dashboard/login` with a 302.
- `test/e2e/dashboard.test.ts` covers the redirect path for unauthenticated requests.

## Verification

```bash
DATABASE_URL=... BUNMAIL_ENV=production DASHBOARD_PASSWORD= bun run dev
# → throws "[config] DASHBOARD_PASSWORD must be set when BUNMAIL_ENV=production..."

DATABASE_URL=... BUNMAIL_ENV=development DASHBOARD_PASSWORD= bun run dev   # ok (dev)
DATABASE_URL=... BUNMAIL_ENV=production DASHBOARD_PASSWORD=secret bun run dev  # ok
```

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 80 unit + 62 e2e = 142 tests pass
- [x] `bun run lint` clean
- [x] Manual: all three env combinations behave as expected
- [x] CI green

Closes #19

 Generated with [Claude Code](https://claude.com/claude-code)