### PR TITLE
feat: emit List-Unsubscribe headers on every outbound message (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `List-Unsubscribe` (and optionally `List-Unsubscribe-Post: List-Unsubscribe=One-Click`) on every outbound message, addressing Gmail and Yahoo's Feb-2024 sender requirements. Per-domain overrides (`unsubscribeEmail`, `unsubscribeUrl`) accepted at `POST /api/v1/domains` and surfaced in the response. Defaults to `unsubscribe@<from-domain>` when no override is set. See [docs/emails.md](docs/emails.md#list-unsubscribe) for the resolution rules. (#40)
 - Cap on outbound email body size — `html` and `text` fields are now limited to 5 MB each via DTO validation; oversize payloads return `422`. (#26)
 - Periodic cleanup for the in-memory HTTP rate-limit map; expired entries are pruned every 5 minutes so the map can't grow unbounded under high cardinality. (#22)
 - Opportunistic STARTTLS on outbound delivery — every recipient MX that advertises STARTTLS is now upgraded to TLS. Documented in `SECURITY.md`. (#21)

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,9 +163,11 @@ Register a new sender domain. Automatically generates a 2048-bit RSA keypair for
 
 **Request Body:**
 
-| Field  | Type   | Required | Description                          |
-|--------|--------|----------|--------------------------------------|
-| `name` | string | Yes      | Domain name (e.g. "example.com")     |
+| Field               | Type   | Required | Description                                                                                      |
+|---------------------|--------|----------|--------------------------------------------------------------------------------------------------|
+| `name`              | string | Yes      | Domain name (e.g. "example.com")                                                                 |
+| `unsubscribeEmail`  | string | No       | Mailbox emitted in `List-Unsubscribe: <mailto:...>`. Defaults to `unsubscribe@<name>` if omitted. |
+| `unsubscribeUrl`    | string | No       | RFC 8058 one-click HTTPS endpoint. When set, mail also carries `List-Unsubscribe-Post: List-Unsubscribe=One-Click`. |
 
 **Response:**
 
@@ -181,10 +183,14 @@ Register a new sender domain. Automatically generates a 2048-bit RSA keypair for
     "dkimVerified": false,
     "dmarcVerified": false,
     "verifiedAt": null,
+    "unsubscribeEmail": null,
+    "unsubscribeUrl": null,
     "createdAt": "2026-03-15T12:00:00.000Z"
   }
 }
 ```
+
+The `unsubscribeEmail` / `unsubscribeUrl` fields shape the `List-Unsubscribe` header BunMail adds to every outbound message sent from this domain. See [docs/emails.md](emails.md#list-unsubscribe) for the resolution rules.
 
 ---
 

--- a/docs/emails.md
+++ b/docs/emails.md
@@ -94,6 +94,21 @@ When an email is created, the sender's domain (from `from` address) is looked up
 - In **production** mode (`BUNMAIL_ENV=production`), the domain must be registered or the request is rejected
 - In **development** mode, unregistered domains are allowed (`domain_id` stays null)
 
+## List-Unsubscribe
+
+Every outbound message carries an RFC 2369 `List-Unsubscribe` header. Resolution rules:
+
+| Domain config (in `domains` table) | Header(s) emitted |
+|---|---|
+| `unsubscribe_email = NULL`, `unsubscribe_url = NULL` | `List-Unsubscribe: <mailto:unsubscribe@{from-domain}>` |
+| `unsubscribe_email = "optout@x.com"` | `List-Unsubscribe: <mailto:optout@x.com>` |
+| `unsubscribe_url = "https://x.com/u/abc"` | `List-Unsubscribe: <mailto:unsubscribe@{from-domain}>, <https://x.com/u/abc>`<br>`List-Unsubscribe-Post: List-Unsubscribe=One-Click` |
+| Both set | Both forms in the same `List-Unsubscribe`, plus the `One-Click` POST header |
+
+**Why always-on?** Gmail and Yahoo's Feb-2024 sender requirements treat the presence of `List-Unsubscribe` as a positive ranking signal, including on transactional mail. The mailto-only form is sufficient for transactional senders. Bulk / promotional senders need the URL form too — Gmail's "high volume" thresholds (>5k/day to gmail) require RFC 8058 one-click via the URL + POST headers.
+
+**Why per-domain config?** The default `unsubscribe@<domain>` mailbox often doesn't exist; emitting unroutable addresses is worse than a working override. Set `unsubscribeEmail` to a real mailbox you read, and `unsubscribeUrl` to a handler that processes the POST body (Gmail sends `List-Unsubscribe=One-Click` form-encoded).
+
 ## Service Methods
 
 ### email.service.ts

--- a/src/modules/domains/dtos/create-domain.dto.ts
+++ b/src/modules/domains/dtos/create-domain.dto.ts
@@ -2,9 +2,32 @@ import { t } from "elysia";
 
 /**
  * Validation schema for POST /api/v1/domains request body.
- * Only requires the domain name — DKIM key generation is handled later.
+ *
+ * Only `name` is required — DKIM key generation is handled later.
+ *
+ * Optional `unsubscribeEmail` / `unsubscribeUrl` override the defaults
+ * BunMail emits in the outbound `List-Unsubscribe` header. Set them
+ * when the default `unsubscribe@<domain>` mailbox isn't a real address
+ * you can read, or when you want RFC 8058 one-click unsubscribe (which
+ * Gmail's bulk-sender rules require).
  */
 export const createDomainDto = t.Object({
   /** The domain name to register (e.g. "example.com") */
   name: t.String({ minLength: 1, maxLength: 255 }),
+
+  /**
+   * Mailbox that receives `List-Unsubscribe: <mailto:...>` requests.
+   * Omit to fall back to `unsubscribe@<domain>`. RFC 5321 caps the
+   * full address at 254 characters.
+   */
+  unsubscribeEmail: t.Optional(
+    t.String({ format: "email", minLength: 3, maxLength: 254 }),
+  ),
+
+  /**
+   * One-click HTTPS unsubscribe endpoint per RFC 8058. When set the
+   * mailer also emits `List-Unsubscribe-Post: List-Unsubscribe=One-Click`.
+   * Leave unset for transactional mail.
+   */
+  unsubscribeUrl: t.Optional(t.String({ format: "uri", minLength: 8, maxLength: 2048 })),
 });

--- a/src/modules/domains/models/domain.schema.ts
+++ b/src/modules/domains/models/domain.schema.ts
@@ -35,6 +35,24 @@ export const domains = pgTable("domains", {
   /** When DNS verification last succeeded (null if never verified) */
   verifiedAt: timestamp("verified_at"),
 
+  /**
+   * Mailbox that receives `List-Unsubscribe` mailto requests for messages
+   * sent from this domain. When null the mailer defaults to
+   * `unsubscribe@<domain>` so a `List-Unsubscribe` header is always
+   * emitted (Gmail/Yahoo Feb-2024 sender requirements). Operators
+   * override this when they don't operate the default mailbox.
+   */
+  unsubscribeEmail: varchar("unsubscribe_email", { length: 255 }),
+
+  /**
+   * One-click HTTPS unsubscribe endpoint per RFC 8058. When set, the
+   * mailer emits `List-Unsubscribe: <mailto:...>, <https://...>` plus
+   * `List-Unsubscribe-Post: List-Unsubscribe=One-Click`, which Gmail
+   * requires for high-volume bulk senders. Leave null for transactional
+   * mail — the mailto-only form is enough.
+   */
+  unsubscribeUrl: text("unsubscribe_url"),
+
   /** When this domain was added */
   createdAt: timestamp("created_at").notNull().defaultNow(),
 

--- a/src/modules/domains/serializations/domain.serialization.ts
+++ b/src/modules/domains/serializations/domain.serialization.ts
@@ -15,6 +15,10 @@ export interface SerializedDomain {
   dkimVerified: boolean;
   dmarcVerified: boolean;
   verifiedAt: Date | null;
+  /** Mailbox used for `List-Unsubscribe`; null means the mailer falls back to `unsubscribe@<name>`. */
+  unsubscribeEmail: string | null;
+  /** One-click HTTPS unsubscribe endpoint; null disables `List-Unsubscribe-Post`. */
+  unsubscribeUrl: string | null;
   createdAt: Date;
 }
 
@@ -33,6 +37,8 @@ export function serializeDomain(domain: Domain): SerializedDomain {
     dkimVerified: domain.dkimVerified,
     dmarcVerified: domain.dmarcVerified,
     verifiedAt: domain.verifiedAt,
+    unsubscribeEmail: domain.unsubscribeEmail,
+    unsubscribeUrl: domain.unsubscribeUrl,
     createdAt: domain.createdAt,
   };
 }

--- a/src/modules/domains/services/domain.service.ts
+++ b/src/modules/domains/services/domain.service.ts
@@ -63,6 +63,8 @@ export async function createDomain(input: CreateDomainInput): Promise<Domain> {
       dkimPrivateKey: privateKey,
       dkimPublicKey: publicKey,
       dkimSelector: "bunmail",
+      unsubscribeEmail: input.unsubscribeEmail ?? null,
+      unsubscribeUrl: input.unsubscribeUrl ?? null,
     })
     .returning();
 

--- a/src/modules/domains/types/domain.types.ts
+++ b/src/modules/domains/types/domain.types.ts
@@ -9,9 +9,16 @@ export type Domain = InferSelectModel<typeof domains>;
 
 /**
  * Input required to create a new domain.
- * Only the domain name is needed — DKIM key generation comes in a later phase.
+ *
+ * `name` is the only required field — DKIM keys are generated server-side.
+ * The unsubscribe fields override the defaults BunMail emits on outbound
+ * `List-Unsubscribe` headers; both are optional.
  */
 export interface CreateDomainInput {
   /** The domain name (e.g. "example.com") */
   name: string;
+  /** Mailbox for `List-Unsubscribe: <mailto:...>`. Defaults to `unsubscribe@<name>`. */
+  unsubscribeEmail?: string;
+  /** RFC 8058 one-click HTTPS unsubscribe endpoint. Optional. */
+  unsubscribeUrl?: string;
 }

--- a/src/modules/emails/services/mailer.service.ts
+++ b/src/modules/emails/services/mailer.service.ts
@@ -16,6 +16,25 @@ export interface DkimOptions {
 }
 
 /**
+ * Inputs for the `List-Unsubscribe` header. Both fields optional —
+ * the mailer always emits at least the mailto form (defaulting to
+ * `unsubscribe@<from-domain>` when `mailto` is omitted), and adds
+ * the HTTPS / `List-Unsubscribe-Post: One-Click` form whenever a
+ * URL is provided.
+ *
+ * Per Gmail's Feb-2024 sender requirements every transactional /
+ * promotional message benefits from a List-Unsubscribe header even
+ * when the recipient doesn't realistically need to unsubscribe —
+ * its presence is a positive ranking signal.
+ */
+export interface UnsubscribeOptions {
+  /** Defaults to `unsubscribe@<from-domain>` if not set. */
+  mailto?: string;
+  /** RFC 8058 one-click endpoint. When set, also emits the One-Click POST header. */
+  url?: string;
+}
+
+/**
  * Resolves the MX server for a recipient's domain and returns
  * the lowest-priority (highest preference) mail exchange host.
  */
@@ -52,6 +71,7 @@ export async function sendMail(options: {
   html?: string | null;
   text?: string | null;
   dkim?: DkimOptions;
+  unsubscribe?: UnsubscribeOptions;
 }): Promise<SendMailResult> {
   logger.info("Sending email via SMTP", {
     from: options.from,
@@ -97,6 +117,25 @@ export async function sendMail(options: {
     html: options.html ?? undefined,
     text: options.text ?? undefined,
   };
+
+  /**
+   * Build `List-Unsubscribe` (and optionally `List-Unsubscribe-Post`)
+   * per RFC 2369 + RFC 8058. Always emit the mailto form — Gmail and
+   * Yahoo's Feb-2024 sender requirements expect it on every legitimate
+   * transactional message. When the operator has configured a one-click
+   * HTTPS endpoint, append the URL form and the POST header so receivers
+   * can offer the in-client one-click unsubscribe button.
+   */
+  const senderDomain = options.from.split("@")[1];
+  if (senderDomain) {
+    const mailto = options.unsubscribe?.mailto ?? `unsubscribe@${senderDomain}`;
+    const url = options.unsubscribe?.url;
+    const headerValue = url ? `<mailto:${mailto}>, <${url}>` : `<mailto:${mailto}>`;
+    mailOptions.headers = {
+      "List-Unsubscribe": headerValue,
+      ...(url && { "List-Unsubscribe-Post": "List-Unsubscribe=One-Click" }),
+    };
+  }
 
   if (options.dkim) {
     mailOptions.dkim = {

--- a/src/modules/emails/services/queue.service.ts
+++ b/src/modules/emails/services/queue.service.ts
@@ -3,7 +3,7 @@ import { db } from "../../../db/index.ts";
 import { emails } from "../models/email.schema.ts";
 import { domains } from "../../domains/models/domain.schema.ts";
 import { sendMail } from "./mailer.service.ts";
-import type { DkimOptions } from "./mailer.service.ts";
+import type { DkimOptions, UnsubscribeOptions } from "./mailer.service.ts";
 import { dispatchEvent } from "../../webhooks/services/webhook-dispatch.service.ts";
 import { logger } from "../../../utils/logger.ts";
 
@@ -133,9 +133,16 @@ async function processEmail(email: typeof emails.$inferSelect): Promise<void> {
     .where(eq(emails.id, emailId));
 
   try {
-    /** Look up DKIM keys for the sender's domain */
+    /**
+     * Look up DKIM keys + unsubscribe overrides for the sender's domain
+     * in a single query. Both fall back gracefully — DKIM stays unsigned
+     * if the domain isn't registered, and `List-Unsubscribe` defaults to
+     * `unsubscribe@<sender-domain>` inside the mailer when overrides are
+     * absent.
+     */
     const senderDomain = email.fromAddress.split("@")[1];
     let dkim: DkimOptions | undefined;
+    let unsubscribe: UnsubscribeOptions | undefined;
 
     if (senderDomain) {
       const [domain] = await db
@@ -143,6 +150,8 @@ async function processEmail(email: typeof emails.$inferSelect): Promise<void> {
           name: domains.name,
           dkimSelector: domains.dkimSelector,
           dkimPrivateKey: domains.dkimPrivateKey,
+          unsubscribeEmail: domains.unsubscribeEmail,
+          unsubscribeUrl: domains.unsubscribeUrl,
         })
         .from(domains)
         .where(eq(domains.name, senderDomain));
@@ -158,6 +167,18 @@ async function processEmail(email: typeof emails.$inferSelect): Promise<void> {
           selector: domain.dkimSelector,
         });
       }
+
+      /**
+       * Pass overrides only when at least one is set. Otherwise leave
+       * `unsubscribe` undefined and let the mailer apply its default
+       * (`unsubscribe@<sender-domain>` mailto, no URL).
+       */
+      if (domain?.unsubscribeEmail || domain?.unsubscribeUrl) {
+        unsubscribe = {
+          mailto: domain.unsubscribeEmail ?? undefined,
+          url: domain.unsubscribeUrl ?? undefined,
+        };
+      }
     }
 
     /** Step 2: Attempt SMTP delivery */
@@ -170,6 +191,7 @@ async function processEmail(email: typeof emails.$inferSelect): Promise<void> {
       html: email.html,
       text: email.textContent,
       dkim,
+      unsubscribe,
     });
 
     /** Step 3a: Success — mark as "sent" and record the SMTP Message-ID */

--- a/test/e2e/dashboard.test.ts
+++ b/test/e2e/dashboard.test.ts
@@ -121,6 +121,8 @@ mock.module("../../src/modules/domains/services/domain.service.ts", () => ({
       dkimVerified: false,
       dmarcVerified: false,
       verifiedAt: null,
+      unsubscribeEmail: null,
+      unsubscribeUrl: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     }),

--- a/test/e2e/domains-api.test.ts
+++ b/test/e2e/domains-api.test.ts
@@ -80,6 +80,8 @@ const mockDomain = {
   dkimVerified: false,
   dmarcVerified: false,
   verifiedAt: null,
+  unsubscribeEmail: null as string | null,
+  unsubscribeUrl: null as string | null,
   createdAt: new Date("2024-01-01"),
   updatedAt: new Date("2024-01-01"),
 };

--- a/test/unit/domain.serialization.test.ts
+++ b/test/unit/domain.serialization.test.ts
@@ -20,6 +20,8 @@ describe("serializeDomain", () => {
     dkimVerified: false,
     dmarcVerified: false,
     verifiedAt: new Date("2024-06-01"),
+    unsubscribeEmail: null as string | null,
+    unsubscribeUrl: null as string | null,
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
   };
@@ -49,5 +51,24 @@ describe("serializeDomain", () => {
   test("strips updatedAt from output", () => {
     const result = serializeDomain(domain);
     expect("updatedAt" in result).toBe(false);
+  });
+
+  test("exposes unsubscribe overrides as nullable fields", () => {
+    /**
+     * The mailer falls back to `unsubscribe@<domain>` when these are
+     * null, so the API needs to surface "unset" distinctly from a real
+     * value the caller previously set.
+     */
+    const noOverrides = serializeDomain(domain);
+    expect(noOverrides.unsubscribeEmail).toBeNull();
+    expect(noOverrides.unsubscribeUrl).toBeNull();
+
+    const withOverrides = serializeDomain({
+      ...domain,
+      unsubscribeEmail: "optout@example.com",
+      unsubscribeUrl: "https://example.com/unsubscribe?id=abc",
+    });
+    expect(withOverrides.unsubscribeEmail).toBe("optout@example.com");
+    expect(withOverrides.unsubscribeUrl).toBe("https://example.com/unsubscribe?id=abc");
   });
 });

--- a/test/unit/get-dkim-dns-record.test.ts
+++ b/test/unit/get-dkim-dns-record.test.ts
@@ -66,6 +66,8 @@ function makeDomain(overrides: Record<string, unknown> = {}) {
     dkimVerified: false,
     dmarcVerified: false,
     verifiedAt: null,
+    unsubscribeEmail: null,
+    unsubscribeUrl: null,
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
     ...overrides,


### PR DESCRIPTION
## Summary

Gmail and Yahoo's Feb-2024 sender requirements treat the presence of `List-Unsubscribe` as a positive ranking signal, even on transactional mail. BunMail now emits it on every outbound message with a sensible default + per-domain override.

## Resolution rules

| Domain config | Headers emitted |
|---|---|
| no override | `List-Unsubscribe: <mailto:unsubscribe@<from-domain>>` |
| `unsubscribeEmail` set | `<mailto:optout@x.com>` instead |
| `unsubscribeUrl` set | URL form appended, plus `List-Unsubscribe-Post: List-Unsubscribe=One-Click` (RFC 8058) |
| both set | combined `List-Unsubscribe`, plus the One-Click POST header |

The mailto form is sufficient for transactional senders. The URL + POST form is what Gmail's high-volume bulk-sender rules require.

## Changes

- **Schema** — two nullable columns on `domains`: `unsubscribe_email` (varchar 255), `unsubscribe_url` (text). Migration `0002_tired_northstar.sql` is two `ADD COLUMN` statements; non-destructive.
- **DTO** — `POST /api/v1/domains` accepts optional `unsubscribeEmail` (email format, ≤254 chars) and `unsubscribeUrl` (URI format, ≤2048 chars).
- **Mailer** — new `UnsubscribeOptions` type; assembles the header from sender domain + optional overrides.
- **Queue** — pulls both columns from the domain lookup (one query, alongside DKIM keys) and passes to the mailer.
- **Serializer** — exposes the fields; `null` distinguishes "use default" from a deliberately set value.
- **Tests** — domain serializer test gains an "exposes unsubscribe overrides as nullable fields" case covering both unset and set; e2e + DKIM-record fixtures updated.
- **Docs** — `docs/api.md` request body + response sample, `docs/emails.md` new "List-Unsubscribe" section with the resolution table and Gmail/Yahoo context, `CHANGELOG.md` entry.

## Out of scope (separate)

- PATCH `/api/v1/domains/:id` to update unsubscribe fields after creation. Currently fields are set at create time only; document working around it as recreate. Worth filing as a follow-up if it bites.
- Default unsubscribe handler (route at `/api/v1/unsubscribe?token=...` to actually process opt-outs and store them). For now BunMail emits the header; the operator owns the receiving end.
- Dashboard form for editing these fields. CLI/API path is enough for this PR.

## Test Plan

- [x] `bunx tsc --noEmit` clean
- [x] 82 unit + 62 e2e = 144 tests pass (1 new unit test, fixtures updated)
- [x] `bun run lint` clean
- [ ] CI green
- [ ] Manual after merge: send a real email; inspect Gmail "Show original" → confirm `List-Unsubscribe` header is present and well-formed

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)