### PR TITLE
refactor: drop `as typeof context` casts across plugins (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `LOG_LEVEL` is now validated at config load — invalid values fail loudly with a clear error instead of silently behaving like the default. (#39)
+- Removed every `as typeof context & { apiKeyId: string }` cast across the email, template, webhook, and inbound plugins. Elysia's type inference flows `apiKeyId` correctly through `.use(authMiddleware).resolve(...).as("scoped")`; the casts were defensive cargo from earlier Elysia versions. The `rate-limit` middleware's standalone-plugin cast is tightened to `{ apiKeyId?: string }` (was `Record<string, unknown>`) — express the exact shape we read. (#36)
 - Auth middleware no longer hashes the bearer token or queries `api_keys` twice per request. The lookup result is cached on the `Request` (via a `WeakMap`) and reused by `resolve`, halving DB load on the auth path. (#27)
 - `api_keys.last_used_at` writes are now throttled to once every 60 s per key. A hot caller no longer fires one `UPDATE` per request; the timestamp can lag by up to the throttle window. (#28)
 

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -84,12 +84,19 @@ export const rateLimitMiddleware = new Elysia({
   name: "rate-limit-middleware",
 }).onBeforeHandle((context) => {
   /**
-   * Read apiKeyId from the derived auth context.
-   * The auth middleware uses `derive()` which adds apiKeyId directly
-   * to the request context. Cast needed because Elysia can't infer
-   * cross-plugin derive types in a standalone middleware.
+   * Read `apiKeyId` from the derived auth context.
+   *
+   * The auth middleware adds `apiKeyId` via `.resolve()`, but this
+   * plugin is its own `Elysia` instance — it doesn't statically know
+   * about the auth middleware's context, so TypeScript can't see the
+   * field. The read is order-dependent: every plugin that uses the
+   * rate-limiter calls `.use(authMiddleware).use(rateLimitMiddleware)`
+   * so by the time this hook fires, `apiKeyId` is already in the
+   * context if auth ran. The narrow `{ apiKeyId?: string }` cast is
+   * preferred over `Record<string, unknown>` because it expresses
+   * exactly the shape we read — anything else would be a real bug.
    */
-  const apiKeyId = (context as Record<string, unknown>)["apiKeyId"] as string | undefined;
+  const { apiKeyId } = context as { apiKeyId?: string };
 
   /**
    * If no apiKeyId is present, auth middleware hasn't run or the route

--- a/src/modules/emails/emails.plugin.ts
+++ b/src/modules/emails/emails.plugin.ts
@@ -44,14 +44,7 @@ export const emailsPlugin = new Elysia({
    */
   .post(
     "/send",
-    async (context) => {
-      /**
-       * apiKeyId is injected by authMiddleware via derive().
-       * Elysia's type inference doesn't propagate derive types across
-       * .use() boundaries, so we access it from the context object.
-       */
-      const { body, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ body, apiKeyId }) => {
       logger.info("POST /api/v1/emails/send", { apiKeyId, to: redactEmail(body.to) });
 
       /** Create the email record — it starts in "queued" status */
@@ -76,9 +69,7 @@ export const emailsPlugin = new Elysia({
 
   .get(
     "/",
-    async (context) => {
-      const { query, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ query, apiKeyId }) => {
       logger.info("GET /api/v1/emails", { apiKeyId, ...query });
 
       const { data, total } = await emailService.listEmails(apiKeyId, {
@@ -118,9 +109,7 @@ export const emailsPlugin = new Elysia({
    */
   .get(
     "/trash",
-    async (context) => {
-      const { query, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ query, apiKeyId }) => {
       logger.info("GET /api/v1/emails/trash", { apiKeyId, ...query });
 
       const { data, total } = await emailService.listTrashedEmails(apiKeyId, {
@@ -155,9 +144,7 @@ export const emailsPlugin = new Elysia({
 
   .get(
     "/:id",
-    async (context) => {
-      const { params, apiKeyId, set } = context as typeof context & { apiKeyId: string };
-
+    async ({ params, apiKeyId, set }) => {
       logger.info("GET /api/v1/emails/:id", { emailId: params.id, apiKeyId });
 
       const email = await emailService.getEmailById(params.id, apiKeyId);
@@ -196,11 +183,7 @@ export const emailsPlugin = new Elysia({
    */
   .delete(
     "/:id",
-    async (context) => {
-      const { params, apiKeyId, set } = context as typeof context & {
-        apiKeyId: string;
-      };
-
+    async ({ params, apiKeyId, set }) => {
       logger.info("DELETE /api/v1/emails/:id", { emailId: params.id, apiKeyId });
 
       const email = await emailService.trashEmail(params.id, apiKeyId);
@@ -232,9 +215,7 @@ export const emailsPlugin = new Elysia({
    */
   .post(
     "/bulk-delete",
-    async (context) => {
-      const { body, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ body, apiKeyId }) => {
       logger.info("POST /api/v1/emails/bulk-delete", {
         count: body.ids.length,
         apiKeyId,
@@ -264,11 +245,7 @@ export const emailsPlugin = new Elysia({
    */
   .post(
     "/:id/restore",
-    async (context) => {
-      const { params, apiKeyId, set } = context as typeof context & {
-        apiKeyId: string;
-      };
-
+    async ({ params, apiKeyId, set }) => {
       logger.info("POST /api/v1/emails/:id/restore", {
         emailId: params.id,
         apiKeyId,
@@ -302,11 +279,7 @@ export const emailsPlugin = new Elysia({
    */
   .delete(
     "/:id/permanent",
-    async (context) => {
-      const { params, apiKeyId, set } = context as typeof context & {
-        apiKeyId: string;
-      };
-
+    async ({ params, apiKeyId, set }) => {
       logger.info("DELETE /api/v1/emails/:id/permanent", {
         emailId: params.id,
         apiKeyId,
@@ -341,9 +314,7 @@ export const emailsPlugin = new Elysia({
    */
   .post(
     "/trash/empty",
-    async (context) => {
-      const { apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ apiKeyId }) => {
       logger.info("POST /api/v1/emails/trash/empty", { apiKeyId });
 
       const deleted = await emailService.emptyEmailsTrash(apiKeyId);

--- a/src/modules/templates/templates.plugin.ts
+++ b/src/modules/templates/templates.plugin.ts
@@ -25,9 +25,7 @@ export const templatesPlugin = new Elysia({
 
   .post(
     "/",
-    async (context) => {
-      const { body, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ body, apiKeyId }) => {
       logger.info("POST /api/v1/templates", { name: body.name });
 
       const template = await templateService.createTemplate(
@@ -57,9 +55,7 @@ export const templatesPlugin = new Elysia({
 
   .get(
     "/",
-    async (context) => {
-      const { apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ apiKeyId }) => {
       const list = await templateService.listTemplates(apiKeyId);
 
       return { success: true, data: list.map(serializeTemplate) };
@@ -76,9 +72,7 @@ export const templatesPlugin = new Elysia({
 
   .get(
     "/:id",
-    async (context) => {
-      const { params, set, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ params, set, apiKeyId }) => {
       const template = await templateService.getTemplateById(params.id, apiKeyId);
 
       if (!template) {
@@ -101,11 +95,7 @@ export const templatesPlugin = new Elysia({
 
   .put(
     "/:id",
-    async (context) => {
-      const { params, body, set, apiKeyId } = context as typeof context & {
-        apiKeyId: string;
-      };
-
+    async ({ params, body, set, apiKeyId }) => {
       const template = await templateService.updateTemplate(params.id, apiKeyId, {
         name: body.name,
         subject: body.subject,
@@ -135,9 +125,7 @@ export const templatesPlugin = new Elysia({
 
   .delete(
     "/:id",
-    async (context) => {
-      const { params, set, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ params, set, apiKeyId }) => {
       const template = await templateService.deleteTemplate(params.id, apiKeyId);
 
       if (!template) {

--- a/src/modules/webhooks/webhooks.plugin.ts
+++ b/src/modules/webhooks/webhooks.plugin.ts
@@ -23,9 +23,7 @@ export const webhooksPlugin = new Elysia({
 
   .post(
     "/",
-    async (context) => {
-      const { body, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ body, apiKeyId }) => {
       logger.info("POST /api/v1/webhooks", { url: body.url, events: body.events });
 
       const { webhook, secret } = await webhookService.createWebhook(
@@ -55,9 +53,7 @@ export const webhooksPlugin = new Elysia({
 
   .get(
     "/",
-    async (context) => {
-      const { apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ apiKeyId }) => {
       const hooks = await webhookService.listWebhooks(apiKeyId);
 
       return {
@@ -77,9 +73,7 @@ export const webhooksPlugin = new Elysia({
 
   .delete(
     "/:id",
-    async (context) => {
-      const { params, set, apiKeyId } = context as typeof context & { apiKeyId: string };
-
+    async ({ params, set, apiKeyId }) => {
       const webhook = await webhookService.deleteWebhook(params.id, apiKeyId);
 
       if (!webhook) {


### PR DESCRIPTION
## Summary

Every authenticated route handler had a defensive cast:

\`\`\`ts
async (context) => {
  const { body, apiKeyId } = context as typeof context & { apiKeyId: string };
  ...
}
\`\`\`

The cast was cargo from an earlier Elysia that didn't propagate \`derive\`/\`resolve\` types across \`.use()\` boundaries. **Modern Elysia (1.4.x) does** — verified by removing one cast first and running \`bunx tsc --noEmit\` clean. The rest were the same pattern.

## Changes

- **15 cast removals** across plugin files. Each handler is now a clean inline destructure: \`async ({ body, apiKeyId }) => { ... }\`.
  - \`src/modules/emails/emails.plugin.ts\` — 9 handlers
  - \`src/modules/templates/templates.plugin.ts\` — 5 handlers
  - \`src/modules/webhooks/webhooks.plugin.ts\` — 3 handlers
- **\`src/middleware/rate-limit.ts\`** — structurally different. \`rateLimitMiddleware\` is its own \`Elysia\` instance that runs after \`authMiddleware\` in the consumer's plugin chain, so its local context doesn't statically know about \`apiKeyId\`. Tightened the cast from \`Record<string, unknown>\` to \`{ apiKeyId?: string }\` (express exactly the shape we read). Comment now explains why the cast is the right tool for that specific case rather than implying the type system is broken.

## Test Plan

- [x] \`bunx tsc --noEmit\` clean (the test that proves Elysia infers it correctly)
- [x] 92 unit + 62 e2e = 154 tests pass
- [x] \`bun run lint\` clean
- [ ] CI green

## Why this matters

- Reduces noise in every handler — readers don't wonder what the cast is hiding.
- Removes a class of "type lies" that would mask a real misconfiguration if \`authMiddleware\` were ever removed from a route.
- Makes the codebase exemplary of Elysia's modern idiom (helps the README's "modern stack" pitch).

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)