### PR TITLE
fix: resolve DKIM by email.domainId, name only as legacy fallback (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Email queue now resolves DKIM keys + `List-Unsubscribe` overrides via the email's `domainId` FK rather than parsing the sender domain out of `fromAddress`. The string-parse path was a correctness hazard for renamed domains and inconsistent with the schema's stamped FK. Falls back to a name-based lookup only when `domainId` is null (legacy rows from before the FK existed). Adds a unit test covering both paths. (#32)
+
 ### Changed
 
 - **Runtime image no longer ships `drizzle-kit`.** Replaced `drizzle-kit migrate` at container start with a 60-line Bun-native runner (`src/db/migrate.ts`) that reads the committed `drizzle/<n>_*.sql` files and tracks applied tags in a new `__bunmail_migrations` table. Eliminates esbuild's bundled Go binary from the production image, closing ~36 Go-stdlib false-positive findings on Trivy's image scan. Existing `db:push`-provisioned databases are auto-baselined on first run (every known migration is recorded as applied without re-running its DDL). The Dockerfile is now multi-stage (install → prod-deps → run) so dev deps never reach the final layer; the run stage also applies the latest Debian security patches at build time. Migrations are now committed to `drizzle/` and removed from `.gitignore`. (#56)

--- a/src/modules/emails/services/queue.service.ts
+++ b/src/modules/emails/services/queue.service.ts
@@ -8,6 +8,82 @@ import { dispatchEvent } from "../../webhooks/services/webhook-dispatch.service.
 import { logger } from "../../../utils/logger.ts";
 import { redactEmail } from "../../../utils/redact.ts";
 
+/**
+ * Subset of the `domains` row used by the queue's DKIM + unsubscribe
+ * resolution. Kept narrow so unit tests can build fixtures without
+ * faking the full Drizzle row type.
+ */
+export interface DomainLookupRow {
+  name: string;
+  dkimSelector: string;
+  dkimPrivateKey: string | null;
+  unsubscribeEmail: string | null;
+  unsubscribeUrl: string | null;
+}
+
+/**
+ * Resolves the `domains` row that should drive DKIM signing and
+ * `List-Unsubscribe` overrides for an outbound email.
+ *
+ * Lookup order:
+ *   1. **By `domainId` (canonical)** — the FK stamped on the email row
+ *      at create-time. Survives sender renames and is the right answer
+ *      even if a future schema allows non-unique names per API key.
+ *   2. **By sender domain name (legacy fallback)** — only used when
+ *      `domainId` is null, which only happens for rows created before
+ *      the FK existed (schema 0001). New rows always carry `domainId`
+ *      when the domain is registered.
+ *
+ * Exported for unit testing — see test/unit/resolve-domain-for-email.test.ts.
+ */
+export async function resolveDomainForEmail(
+  email: { domainId: string | null; fromAddress: string },
+  queries: {
+    byId: (id: string) => Promise<DomainLookupRow | undefined>;
+    byName: (name: string) => Promise<DomainLookupRow | undefined>;
+  },
+): Promise<DomainLookupRow | undefined> {
+  /** Primary path — FK is the canonical pointer. */
+  if (email.domainId !== null) {
+    return queries.byId(email.domainId);
+  }
+
+  /** Legacy fallback — pre-FK rows. Skip if `fromAddress` is malformed. */
+  const senderDomain = email.fromAddress.split("@")[1];
+  if (!senderDomain) return undefined;
+  return queries.byName(senderDomain);
+}
+
+/** Concrete `byId` query against the live Drizzle DB. */
+async function queryDomainById(id: string): Promise<DomainLookupRow | undefined> {
+  const [row] = await db
+    .select({
+      name: domains.name,
+      dkimSelector: domains.dkimSelector,
+      dkimPrivateKey: domains.dkimPrivateKey,
+      unsubscribeEmail: domains.unsubscribeEmail,
+      unsubscribeUrl: domains.unsubscribeUrl,
+    })
+    .from(domains)
+    .where(eq(domains.id, id));
+  return row;
+}
+
+/** Concrete `byName` query against the live Drizzle DB. */
+async function queryDomainByName(name: string): Promise<DomainLookupRow | undefined> {
+  const [row] = await db
+    .select({
+      name: domains.name,
+      dkimSelector: domains.dkimSelector,
+      dkimPrivateKey: domains.dkimPrivateKey,
+      unsubscribeEmail: domains.unsubscribeEmail,
+      unsubscribeUrl: domains.unsubscribeUrl,
+    })
+    .from(domains)
+    .where(eq(domains.name, name));
+  return row;
+}
+
 /** How often the queue checks for new emails to send (in ms) */
 const POLL_INTERVAL_MS = 2000;
 
@@ -139,51 +215,42 @@ async function processEmail(email: typeof emails.$inferSelect): Promise<void> {
 
   try {
     /**
-     * Look up DKIM keys + unsubscribe overrides for the sender's domain
-     * in a single query. Both fall back gracefully — DKIM stays unsigned
-     * if the domain isn't registered, and `List-Unsubscribe` defaults to
+     * Look up DKIM keys + unsubscribe overrides for the sender's domain.
+     * Both fall back gracefully — DKIM stays unsigned if the domain row
+     * is missing, and `List-Unsubscribe` defaults to
      * `unsubscribe@<sender-domain>` inside the mailer when overrides are
      * absent.
      */
-    const senderDomain = email.fromAddress.split("@")[1];
+    const domain = await resolveDomainForEmail(email, {
+      byId: queryDomainById,
+      byName: queryDomainByName,
+    });
+
     let dkim: DkimOptions | undefined;
     let unsubscribe: UnsubscribeOptions | undefined;
 
-    if (senderDomain) {
-      const [domain] = await db
-        .select({
-          name: domains.name,
-          dkimSelector: domains.dkimSelector,
-          dkimPrivateKey: domains.dkimPrivateKey,
-          unsubscribeEmail: domains.unsubscribeEmail,
-          unsubscribeUrl: domains.unsubscribeUrl,
-        })
-        .from(domains)
-        .where(eq(domains.name, senderDomain));
+    if (domain?.dkimPrivateKey) {
+      dkim = {
+        domainName: domain.name,
+        keySelector: domain.dkimSelector,
+        privateKey: domain.dkimPrivateKey,
+      };
+      logger.debug("DKIM signing enabled", {
+        domain: domain.name,
+        selector: domain.dkimSelector,
+      });
+    }
 
-      if (domain?.dkimPrivateKey) {
-        dkim = {
-          domainName: domain.name,
-          keySelector: domain.dkimSelector,
-          privateKey: domain.dkimPrivateKey,
-        };
-        logger.debug("DKIM signing enabled", {
-          domain: domain.name,
-          selector: domain.dkimSelector,
-        });
-      }
-
-      /**
-       * Pass overrides only when at least one is set. Otherwise leave
-       * `unsubscribe` undefined and let the mailer apply its default
-       * (`unsubscribe@<sender-domain>` mailto, no URL).
-       */
-      if (domain?.unsubscribeEmail || domain?.unsubscribeUrl) {
-        unsubscribe = {
-          mailto: domain.unsubscribeEmail ?? undefined,
-          url: domain.unsubscribeUrl ?? undefined,
-        };
-      }
+    /**
+     * Pass overrides only when at least one is set. Otherwise leave
+     * `unsubscribe` undefined and let the mailer apply its default
+     * (`unsubscribe@<sender-domain>` mailto, no URL).
+     */
+    if (domain?.unsubscribeEmail || domain?.unsubscribeUrl) {
+      unsubscribe = {
+        mailto: domain.unsubscribeEmail ?? undefined,
+        url: domain.unsubscribeUrl ?? undefined,
+      };
     }
 
     /** Step 2: Attempt SMTP delivery */

--- a/test/unit/resolve-domain-for-email.test.ts
+++ b/test/unit/resolve-domain-for-email.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from "bun:test";
+import {
+  resolveDomainForEmail,
+  type DomainLookupRow,
+} from "../../src/modules/emails/services/queue.service.ts";
+
+/**
+ * Unit tests for the queue's domain resolver. Covers both the canonical
+ * FK path (`email.domainId`) and the legacy fallback (sender-domain name)
+ * documented in #32. Queries are injected so the test can assert which
+ * lookup ran without standing up a database.
+ */
+
+const sampleRow: DomainLookupRow = {
+  name: "example.com",
+  dkimSelector: "bunmail",
+  dkimPrivateKey: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+  unsubscribeEmail: null,
+  unsubscribeUrl: null,
+};
+
+/**
+ * Builds a `queries` pair whose calls are recorded so each test can
+ * assert which path was taken (FK vs name fallback).
+ */
+function makeQueries(opts: {
+  byIdResult?: DomainLookupRow;
+  byNameResult?: DomainLookupRow;
+}): {
+  queries: Parameters<typeof resolveDomainForEmail>[1];
+  calls: { byId: string[]; byName: string[] };
+} {
+  const calls = { byId: [] as string[], byName: [] as string[] };
+  return {
+    calls,
+    queries: {
+      byId: async (id) => {
+        calls.byId.push(id);
+        return opts.byIdResult;
+      },
+      byName: async (name) => {
+        calls.byName.push(name);
+        return opts.byNameResult;
+      },
+    },
+  };
+}
+
+describe("resolveDomainForEmail — FK path", () => {
+  test("looks up by domainId when set, never falls back to name", async () => {
+    const { queries, calls } = makeQueries({ byIdResult: sampleRow });
+
+    const result = await resolveDomainForEmail(
+      { domainId: "dom_123", fromAddress: "hello@example.com" },
+      queries,
+    );
+
+    expect(result).toBe(sampleRow);
+    expect(calls.byId).toEqual(["dom_123"]);
+    expect(calls.byName).toEqual([]);
+  });
+
+  test("returns undefined and does NOT fall back when byId misses", async () => {
+    /**
+     * `ON DELETE SET NULL` means a missing domainId becomes null on the
+     * email row, not an orphan FK. So if byId returns undefined, the
+     * domain genuinely no longer exists — falling back to a name lookup
+     * would re-attach a different (potentially stale) domain row, which
+     * is the bug the strict-FK path is meant to prevent.
+     */
+    const { queries, calls } = makeQueries({ byIdResult: undefined });
+
+    const result = await resolveDomainForEmail(
+      { domainId: "dom_deleted", fromAddress: "hello@example.com" },
+      queries,
+    );
+
+    expect(result).toBeUndefined();
+    expect(calls.byId).toEqual(["dom_deleted"]);
+    expect(calls.byName).toEqual([]);
+  });
+});
+
+describe("resolveDomainForEmail — legacy name fallback", () => {
+  test("looks up by sender domain when domainId is null", async () => {
+    const { queries, calls } = makeQueries({ byNameResult: sampleRow });
+
+    const result = await resolveDomainForEmail(
+      { domainId: null, fromAddress: "hello@example.com" },
+      queries,
+    );
+
+    expect(result).toBe(sampleRow);
+    expect(calls.byId).toEqual([]);
+    expect(calls.byName).toEqual(["example.com"]);
+  });
+
+  test("returns undefined when fromAddress has no @ (malformed legacy row)", async () => {
+    const { queries, calls } = makeQueries({});
+
+    const result = await resolveDomainForEmail(
+      { domainId: null, fromAddress: "not-an-email" },
+      queries,
+    );
+
+    expect(result).toBeUndefined();
+    expect(calls.byId).toEqual([]);
+    expect(calls.byName).toEqual([]);
+  });
+
+  test("returns undefined when fallback name lookup misses", async () => {
+    const { queries } = makeQueries({ byNameResult: undefined });
+
+    const result = await resolveDomainForEmail(
+      { domainId: null, fromAddress: "hello@unregistered.com" },
+      queries,
+    );
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #32.

`processEmail` now resolves DKIM keys + `List-Unsubscribe` overrides via the email row's `domainId` FK instead of parsing the sender domain out of `fromAddress`. The string-parse path was a correctness hazard for renamed domains and inconsistent with the schema's `ON DELETE SET NULL` design intent — the FK is the canonical pointer.

## Changes

- [src/modules/emails/services/queue.service.ts](src/modules/emails/services/queue.service.ts) — extract `resolveDomainForEmail(email, { byId, byName })` as a pure function with injected query callbacks; primary lookup is now `byId(email.domainId)`, falling back to `byName(senderDomain)` only when `domainId` is null (legacy rows from before the FK existed in schema 0001). When `byId` misses, we deliberately do **not** fall back — `ON DELETE SET NULL` already nulls `domainId` on row deletion, so a missing FK target means the domain genuinely no longer exists.
- [test/unit/resolve-domain-for-email.test.ts](test/unit/resolve-domain-for-email.test.ts) — new unit test covering: FK path hits `byId` only; FK miss returns undefined without falling back; legacy null-FK path hits `byName`; malformed `fromAddress` (no `@`) returns undefined; legacy fallback miss returns undefined.
- [CHANGELOG.md](CHANGELOG.md) — entry under `[Unreleased]`.

## Why this matters

- **Renames:** if a domain row is renamed (e.g. selector rotation script that recreates with a new name), every email already enqueued has `fromAddress` with the old name. The name lookup misses; the FK lookup still succeeds.
- **Code clarity:** parsing user-input strings to look up referential data is the kind of subtle bug that slips past code review. Using the FK aligns with how the schema was designed.

## Local validation

- [x] `bunx tsc --noEmit` clean
- [x] `bun test test/unit` (97 pass — 5 new)
- [x] `bun test test/e2e` (62 pass)
- [x] `bun run lint` clean

## Test plan

- [ ] CI green.
- [ ] After merge: send an email from a registered domain, confirm DKIM signature still attaches in the wire log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)