### PR TITLE
ci: silence gitleaks on documentation placeholders + test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,51 @@
+# gitleaks configuration for BunMail.
+#
+# Inherits the upstream default ruleset (extend.useDefault = true), then
+# layers on stopwords + path allowlists for documentation placeholders
+# and test fixtures.
+#
+# Why this exists:
+#   PR-time gitleaks runs scan only the latest commit's diff, so doc /
+#   fixture content that's been stable for a while never gets re-flagged.
+#   The weekly scheduled scan walks the whole tree and surfaced 15 false
+#   positives — every one a placeholder Bearer token or a fake PEM block
+#   with the literal word SECRET. None are real secrets.
+#
+# stopWords match case-insensitively against the captured secret. Real
+# `bm_live_<32 hex chars>` keys wouldn't contain any of these substrings,
+# so the filter is precise: a placeholder slips through, a leaked real
+# key still fails the build.
+#
+# `paths` allowlists are kept narrow — only test files and explicitly-
+# example documentation files. Application code under `src/` (excluding
+# the homepage code-snippet block) stays subject to every default rule.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Doc placeholders + fixture key material — see header comment for rationale"
+
+stopWords = [
+  # curl-auth-header: README and docs use these placeholder Bearer tokens
+  "YOUR_KEY",
+  "YOUR_API_KEY",
+  "YOUR_SEED_KEY",
+  "your-api-key",
+  # generic-api-key: dashboard tests carry a fake bm_live_test... fixture,
+  # and docs/api.md ships an example response with a placeholder
+  # `bm_live_a1b2c3d4...` key (the `a1b2` repeating pattern marks it as
+  # documentation, not a real entropy-rich key).
+  "bm_live_test",
+  "bm_live_a1b2",
+  # private-key: test fixtures use a literal `SECRET` between PEM markers
+  "SECRET",
+]
+
+paths = [
+  # Test fixtures sometimes carry fake PEM blocks (`SECRET` between
+  # BEGIN/END markers). The dashboard test seeds a fake bm_live_test... key.
+  '''^test/''',
+  # Internal planning doc retained for posterity; not user-facing.
+  '''^BunMail-Plan\.md$''',
+]


### PR DESCRIPTION
## Summary

The weekly scheduled `Security` workflow has been failing since the gitleaks job was introduced. PR-time scans only see the latest commit's diff, so stable documentation and test fixtures never get re-flagged — but the **scheduled scan walks the whole tree** and turned up 15 false positives:

- **curl-auth-header (8):** placeholder Bearer tokens in `README.md`, `docs/self-hosting.md`, `docs/api.md`, `BunMail-Plan.md`, and the homepage code-snippet block in `src/pages/routes/landing.tsx` (e.g. `YOUR_KEY`, `your-api-key`, `YOUR_SEED_KEY`, `bm_live_a1b2c3d4...`).
- **private-key (2):** test fixtures in `test/unit/domain.serialization.test.ts` and `test/e2e/domains-api.test.ts` that ship a fake PEM block with the literal word `SECRET` between BEGIN/END markers.
- **generic-api-key (5):** the dashboard test seeds a `bm_live_test1234...` mock; `docs/api.md` shows an example response with a `bm_live_a1b2c3d4...` placeholder; `docs/self-hosting.md` has a few more curl examples.

None are real secrets — every flagged value is a documentation example or a long-lived test fixture.

Run that triggered this: https://github.com/mohamedboukari/bunmail/actions/runs/25310853108

## Approach

Add a `.gitleaks.toml` that **extends defaults** (`useDefault = true`) — every upstream rule still applies to application code — and layers two filters:

1. **`stopWords`** — case-insensitive substring match against the captured secret. The substrings (`YOUR_KEY`, `YOUR_API_KEY`, `YOUR_SEED_KEY`, `your-api-key`, `bm_live_test`, `bm_live_a1b2`, `SECRET`) cannot appear inside a real `bm_live_<32 hex chars>` API key, so a leaked production key would still fail the build.
2. **`paths`** — narrow allowlist limited to `test/` and the internal `BunMail-Plan.md`. Source under `src/` (including the homepage code-snippet block) stays subject to every default rule; the placeholder there is silenced via stopWords, not paths.

## Local validation

Smoke-tested with the same `gitleaks v8.24.3` pinned in [.github/workflows/security.yml](.github/workflows/security.yml):

```bash
docker run --rm -v "$(pwd):/repo" -w /repo zricethezav/gitleaks:v8.24.3 \
  detect --config=.gitleaks.toml --redact -v
```

Before:
```
WRN leaks found: 15
```

After:
```
INF 67 commits scanned.
INF no leaks found
```

## Test plan

- [ ] PR-time gitleaks job passes (it scans only this commit's diff — only the new `.gitleaks.toml`, so should be clean).
- [ ] After merge, manually trigger the weekly Security workflow (or wait for next Monday's cron at `0 7 * * 1`) — expect `no leaks found`.

Generated with [Claude Code](https://claude.com/claude-code)