### PR TITLE
feat: per-API-key suppression list with send-time gate (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Suppression list.** New `suppressions` table + `/api/v1/suppressions` CRUD endpoints (`POST`, `GET`, `GET /:id`, `DELETE /:id`). The list is **per-API-key** (different keys often represent different customer environments — one's bounces shouldn't gate another's sends). `POST /api/v1/emails/send` now runs a gate against the calling key's suppression list before any other work; suppressed recipients return HTTP 422 with `code: "RECIPIENT_SUPPRESSED"` and `suppressionId` so clients can pivot directly to `DELETE /api/v1/suppressions/:id`. The gate normalises addresses (case-fold, trim) so `Alice@Example.com` and `alice@example.com` resolve to the same row. Auto-suppression on hard bounces is scaffolded via an internal `addFromBounce()` service method and will be wired up by #24 (DSN parsing). See [docs/suppressions.md](docs/suppressions.md). (#25)
+
 ### Security
 
 - **Breaking — DKIM private keys are now encrypted at rest.** Every `domains.dkim_private_key` is encrypted with AES-256-GCM using a new required `DKIM_ENCRYPTION_KEY` env var (32 bytes, base64). Stored as `v1:<iv>:<ciphertext>:<auth-tag>`. A DB dump without the env key leaks no signing material. Operators must add `DKIM_ENCRYPTION_KEY=$(openssl rand -base64 32)` to `.env` **before** pulling this version — boot fails loudly if it's missing or not 32 bytes. Existing rows are auto-encrypted on first boot via [src/db/encrypt-domain-keys.ts](src/db/encrypt-domain-keys.ts) (idempotent — already-encrypted rows are skipped on subsequent restarts). Rotation is documented in `SECURITY.md`. Decrypt failure at send time is fail-open (logs an error and sends unsigned) so a key-rotation accident can't take down outbound delivery. (#23)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Run [mail-tester.com](https://www.mail-tester.com) to get a deliverability score
 - **Inbound SMTP** — receive and store incoming mail with DNSBL, recipient validation, and per-IP rate limiting
 - **API key auth** — SHA-256 hashed Bearer tokens with sliding-window rate limiting
 - **Trash + auto-purge** — Gmail-style soft delete on outbound and inbound, restorable until purged after `TRASH_RETENTION_DAYS` (default 7)
+- **Suppression list** — per-API-key list of addresses we refuse to send to; gate runs at `POST /emails/send` so bounced/unsubscribed recipients can't re-tank IP reputation
 - **Web dashboard** — server-rendered (Elysia JSX), bulk operations, real-time stats (24h sent, success rate, queue depth)
 - **OpenAPI 3.0** — interactive docs at `/api/docs`
 - **Type-safe** — strict TypeScript, Drizzle ORM, no `any`

--- a/docs/api.md
+++ b/docs/api.md
@@ -396,6 +396,65 @@ Revoke an API key (soft delete).
 
 ---
 
+### Suppressions
+
+Per-API-key suppression list — addresses we refuse to send to. See [`docs/suppressions.md`](suppressions.md) for scoping rules, the bounce-handling roadmap, and the schema.
+
+All endpoints are prefixed with `/api/v1/suppressions`.
+
+#### `POST /api/v1/suppressions`
+
+Manually add an address. Idempotent — re-suppressing an existing `(api_key, email)` upserts the row.
+
+**Body:**
+
+```json
+{
+  "email": "user@example.com",
+  "reason": "manual",
+  "expiresAt": null
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `email` | string | Required. Validated against the `email` format. |
+| `reason` | `"bounce" \| "complaint" \| "manual" \| "unsubscribe"` | Defaults to `"manual"`. |
+| `expiresAt` | ISO-8601 datetime or `null` | Optional. `null` (default) = permanent. |
+
+**Response:** the serialized suppression row.
+
+#### `GET /api/v1/suppressions`
+
+Paginated list, scoped to the calling API key.
+
+**Query params:** `page` (default `1`), `limit` (default `20`, max `100`), `email` (optional exact-match filter).
+
+#### `GET /api/v1/suppressions/:id`
+
+Returns a single suppression. 404 if it doesn't exist or belongs to a different key.
+
+#### `DELETE /api/v1/suppressions/:id`
+
+Hard-deletes the suppression. The recipient becomes eligible for sends from this API key immediately.
+
+#### Send-time rejection
+
+When `POST /api/v1/emails/send` is called with a recipient on the suppression list, the response is:
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+
+{
+  "success": false,
+  "error": "Recipient is on the suppression list. Remove the suppression first if this is intentional.",
+  "code": "RECIPIENT_SUPPRESSED",
+  "suppressionId": "sup_a1b2c3..."
+}
+```
+
+No row is inserted into `emails`, no queue entry is created.
+
 ## Error Response Format
 
 All error responses follow this shape:
@@ -406,6 +465,8 @@ All error responses follow this shape:
   "error": "Human-readable error message"
 }
 ```
+
+Some 422 responses carry additional structured fields — e.g. suppression-list rejection carries `code: "RECIPIENT_SUPPRESSED"` and `suppressionId` so clients can pivot to `DELETE /api/v1/suppressions/:id`.
 
 | Status | Meaning                  |
 |--------|--------------------------|

--- a/docs/suppressions.md
+++ b/docs/suppressions.md
@@ -1,0 +1,109 @@
+# Suppressions Module
+
+The suppression list is the gate between an API request and the email queue. Addresses on the list are rejected at `POST /api/v1/emails/send` with HTTP 422 and never reach the queue, the SMTP path, or the recipient's mailbox.
+
+The list exists because **repeated sends to bouncing addresses are the fastest way to kill IP reputation**. Receivers (Gmail, Yahoo, Outlook) track sender reputation per-IP and per-domain; once you've sent to a few hundred non-existent mailboxes, your messages start landing in spam — even for legitimate recipients.
+
+## Scoping
+
+Suppressions are **per `api_key_id`**, not global. Different API keys often represent different customer environments (transactional / marketing / dev), so one key's bounces should never gate another's sends. Mirrors what SES, SendGrid, and Resend do.
+
+A consequence: revoking a key cascades to its suppression list (`ON DELETE CASCADE`). If you rotate a key and want its suppressions to carry over, copy them to the new key first via the API.
+
+## Lookup behaviour
+
+The gate normalises the recipient address before the lookup: `Alice@Example.COM` and `alice@example.com` resolve to the same suppression. RFC 5321 says the local part is technically case-sensitive, but every real receiver folds case, and matching that behaviour at the gate avoids surprise bypasses.
+
+A suppression is **active** when:
+- the row exists for `(api_key_id, normalised_email)`, AND
+- `expires_at IS NULL` (permanent), OR `expires_at > now()` (not yet expired)
+
+Expired rows stay in the table — they're not auto-purged today. If you need cleanup, schedule a background job; for typical usage the table stays small.
+
+## Reasons
+
+| Value | When |
+|---|---|
+| `bounce` | Auto-set by future bounce processing (#24). The DSN parser will call `addFromBounce()` and persist `bounce_type` + `diagnostic_code` from the SMTP enhanced status code. |
+| `complaint` | Reserved for FBL (Feedback Loop) processing — when a recipient marks your message as spam. Not implemented yet. |
+| `manual` | Operator/customer added the address themselves (e.g. "I know this address bounces, just block it"). |
+| `unsubscribe` | Reserved for future one-click unsubscribe handling per Gmail's Feb-2024 sender requirements. The DB column accepts it today; no endpoint sets it yet. |
+
+The DB column is plain `text` for forward compatibility — a finer split (e.g. `bounce.hard.no_user`) can land later without a migration. The API DTO restricts incoming reasons to the four values above.
+
+## Schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `varchar(36)` PK | `sup_<24 hex>` |
+| `api_key_id` | `varchar(36)` FK → `api_keys(id)` | `ON DELETE CASCADE` |
+| `email` | `varchar(255)` | Stored lower-case, trimmed |
+| `reason` | `text` | One of `bounce | complaint | manual | unsubscribe` (validated at API boundary) |
+| `bounce_type` | `varchar(20)` | `hard | soft | null` |
+| `diagnostic_code` | `text` | SMTP enhanced status code, e.g. `5.1.1` |
+| `source_email_id` | `varchar(36)` FK → `emails(id)` | `ON DELETE SET NULL` |
+| `expires_at` | `timestamptz` | Null = permanent |
+| `created_at` | `timestamptz` | Default `now()` |
+
+Indexes:
+- `UNIQUE (api_key_id, email)` — service uses this for `ON CONFLICT DO UPDATE`
+- `(api_key_id, email)` — composite btree, serves the gate's hot lookup
+
+## API surface
+
+All endpoints are scoped to the calling key's `apiKeyId` (read from the auth middleware). Full request/response shapes live in [`docs/api.md`](api.md#suppressions).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/v1/suppressions` | Manual add (idempotent — re-suppressing upserts) |
+| `GET` | `/api/v1/suppressions` | Paginated list, optional `?email=` exact-match filter |
+| `GET` | `/api/v1/suppressions/:id` | Read one |
+| `DELETE` | `/api/v1/suppressions/:id` | Remove (recipient becomes eligible immediately) |
+
+## Behaviour at `POST /api/v1/emails/send`
+
+When the recipient is on the list, the response is:
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/json
+
+{
+  "success": false,
+  "error": "Recipient is on the suppression list. Remove the suppression first if this is intentional.",
+  "code": "RECIPIENT_SUPPRESSED",
+  "suppressionId": "sup_a1b2c3..."
+}
+```
+
+The `suppressionId` lets clients pivot directly to `DELETE /api/v1/suppressions/:id` if the block was a mistake.
+
+The email is **not** inserted into the `emails` table. There's no row to retry, no queue entry, no SMTP attempt — the gate is hard-fail before any side effect.
+
+## Upgrade path: auto-suppression on bounces (#24)
+
+This module ships the storage and the manual-add API. The full acceptance-criteria item from #25 — "auto-suppress on hard bounce / repeated soft bounce" — depends on bounce parsing, which is tracked in #24.
+
+When #24 lands it'll call:
+
+```ts
+import { addFromBounce } from "src/modules/suppressions/services/suppression.service.ts";
+
+await addFromBounce(apiKeyId, {
+  email: parsedDsn.recipient,
+  bounceType: parsedDsn.classify(),  // "hard" | "soft"
+  diagnosticCode: parsedDsn.statusCode,
+  sourceEmailId: msgId,
+  expiresAt: bounceType === "soft" ? addDays(new Date(), 7) : null,
+});
+```
+
+The current `processEmail` retry path **does not** auto-suppress on `MAX_ATTEMPTS` exhaustion, even though that's tempting — without DSN parsing we can't tell hard bounces from network blips, and crude auto-suppression would block legitimate sends.
+
+## Out of scope (separate tickets)
+
+- One-click unsubscribe endpoint (Gmail Feb-2024 List-Unsubscribe-Post)
+- Complaint Feedback Loop (FBL) ingestion
+- Bulk import (CSV upload)
+- Dashboard UI for managing suppressions
+- Auto-purge of expired rows

--- a/drizzle/0003_nifty_phantom_reporter.sql
+++ b/drizzle/0003_nifty_phantom_reporter.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "suppressions" (
+	"id" varchar(36) PRIMARY KEY NOT NULL,
+	"api_key_id" varchar(36) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"reason" text NOT NULL,
+	"bounce_type" varchar(20),
+	"diagnostic_code" text,
+	"source_email_id" varchar(36),
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "suppressions" ADD CONSTRAINT "suppressions_api_key_id_api_keys_id_fk" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "suppressions" ADD CONSTRAINT "suppressions_source_email_id_emails_id_fk" FOREIGN KEY ("source_email_id") REFERENCES "public"."emails"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "suppressions_api_key_email_unique" ON "suppressions" USING btree ("api_key_id","email");--> statement-breakpoint
+CREATE INDEX "suppressions_api_key_email_idx" ON "suppressions" USING btree ("api_key_id","email");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,799 @@
+{
+  "id": "bdfa8888-145a-4951-8bcc-f487c24d7deb",
+  "prevId": "9e09134e-400f-4f8c-b603-472c9c463dd5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dkim_private_key": {
+          "name": "dkim_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bunmail'"
+        },
+        "spf_verified": {
+          "name": "spf_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dkim_verified": {
+          "name": "dkim_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dmarc_verified": {
+          "name": "dmarc_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_email": {
+          "name": "unsubscribe_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_url": {
+          "name": "unsubscribe_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domains_name_unique": {
+          "name": "domains_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_emails_status_created": {
+          "name": "idx_emails_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_emails_api_key_id": {
+          "name": "idx_emails_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_emails_api_key_deleted": {
+          "name": "idx_emails_api_key_deleted",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "emails_api_key_id_api_keys_id_fk": {
+          "name": "emails_api_key_id_api_keys_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "emails_domain_id_domains_id_fk": {
+          "name": "emails_domain_id_domains_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_emails": {
+      "name": "inbound_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbound_received_at": {
+          "name": "idx_inbound_received_at",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_deleted_at": {
+          "name": "idx_inbound_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppressions": {
+      "name": "suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_code": {
+          "name": "diagnostic_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "suppressions_api_key_email_unique": {
+          "name": "suppressions_api_key_email_unique",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suppressions_api_key_email_idx": {
+          "name": "suppressions_api_key_email_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppressions_api_key_id_api_keys_id_fk": {
+          "name": "suppressions_api_key_id_api_keys_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suppressions_source_email_id_emails_id_fk": {
+          "name": "suppressions_source_email_id_emails_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "source_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "templates_api_key_id_api_keys_id_fk": {
+          "name": "templates_api_key_id_api_keys_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhooks_api_key_id_api_keys_id_fk": {
+          "name": "webhooks_api_key_id_api_keys_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777773461731,
       "tag": "0002_tired_northstar",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778188251640,
+      "tag": "0003_nifty_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,3 +12,4 @@ export { emails } from "../modules/emails/models/email.schema.ts";
 export { webhooks } from "../modules/webhooks/models/webhook.schema.ts";
 export { templates } from "../modules/templates/models/template.schema.ts";
 export { inboundEmails } from "../modules/inbound/models/inbound-email.schema.ts";
+export { suppressions } from "../modules/suppressions/models/suppression.schema.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { domainsPlugin } from "./modules/domains/domains.plugin.ts";
 import { webhooksPlugin } from "./modules/webhooks/webhooks.plugin.ts";
 import { templatesPlugin } from "./modules/templates/templates.plugin.ts";
 import { inboundPlugin } from "./modules/inbound/inbound.plugin.ts";
+import { suppressionsPlugin } from "./modules/suppressions/suppressions.plugin.ts";
+import { SuppressedRecipientError } from "./modules/suppressions/errors.ts";
 import { pagesPlugin } from "./pages/pages.plugin.tsx";
 import { landingPlugin } from "./pages/landing.plugin.tsx";
 import { faviconPlugin } from "./pages/favicon.ts";
@@ -69,6 +71,11 @@ const app = new Elysia()
             description: "Create reusable email templates with variable substitution",
           },
           { name: "Inbound", description: "View received inbound emails" },
+          {
+            name: "Suppressions",
+            description:
+              "Manage the per-API-key suppression list — addresses that should never receive mail",
+          },
           { name: "Health", description: "Server health checks" },
         ],
         components: {
@@ -102,6 +109,22 @@ const app = new Elysia()
       }
 
       return { success: false, error: "Not found" };
+    }
+
+    /**
+     * Suppression-list rejection (#25). The service throws
+     * `SuppressedRecipientError`; map to 422 with structured body so
+     * clients can pivot to `DELETE /api/v1/suppressions/:id` via the
+     * `suppressionId` field.
+     */
+    if (error instanceof SuppressedRecipientError) {
+      set.status = 422;
+      return {
+        success: false,
+        error: error.message,
+        code: "RECIPIENT_SUPPRESSED",
+        suppressionId: error.suppressionId,
+      };
     }
 
     const message = error instanceof Error ? error.message : "Internal server error";
@@ -147,6 +170,8 @@ const app = new Elysia()
   .use(templatesPlugin)
   /** Inbound module — GET / (list), GET /:id */
   .use(inboundPlugin)
+  /** Suppressions module — POST /, GET /, GET /:id, DELETE /:id */
+  .use(suppressionsPlugin)
   /** Dashboard — server-rendered UI under /dashboard */
   .use(pagesPlugin)
   .listen({

--- a/src/modules/emails/services/email.service.ts
+++ b/src/modules/emails/services/email.service.ts
@@ -4,6 +4,8 @@ import { emails } from "../models/email.schema.ts";
 import { domains } from "../../domains/models/domain.schema.ts";
 import { templates } from "../../templates/models/template.schema.ts";
 import { renderTemplate } from "../../templates/services/template.service.ts";
+import { isSuppressed } from "../../suppressions/services/suppression.service.ts";
+import { SuppressedRecipientError } from "../../suppressions/errors.ts";
 import { generateId } from "../../../utils/id.ts";
 import { logger } from "../../../utils/logger.ts";
 import { redactEmail } from "../../../utils/redact.ts";
@@ -32,6 +34,29 @@ export async function createEmail(
     to: redactEmail(input.to),
     apiKeyId,
   });
+
+  /**
+   * Suppression gate (#25). Reject sends to addresses on the per-API-key
+   * suppression list before any other work — no template lookup, no
+   * domain check, no INSERT into `emails`. The error class is mapped to
+   * HTTP 422 by the global `onError` handler in `src/index.ts`, with the
+   * `suppressionId` surfaced in the body so callers can pivot directly
+   * to `DELETE /api/v1/suppressions/:id` when they want to undo.
+   */
+  const suppressed = await isSuppressed(apiKeyId, input.to);
+  if (suppressed) {
+    logger.warn("Send blocked by suppression list", {
+      id,
+      apiKeyId,
+      to: redactEmail(input.to),
+      suppressionId: suppressed.id,
+      reason: suppressed.reason,
+    });
+    throw new SuppressedRecipientError({
+      suppressionId: suppressed.id,
+      recipient: input.to,
+    });
+  }
 
   let subject = input.subject ?? "";
   let htmlContent = input.html ?? null;

--- a/src/modules/suppressions/dtos/create-suppression.dto.ts
+++ b/src/modules/suppressions/dtos/create-suppression.dto.ts
@@ -1,0 +1,30 @@
+import { t } from "elysia";
+import { SUPPRESSION_REASONS } from "../types/suppression.types.ts";
+
+/**
+ * Validation schema for `POST /api/v1/suppressions` — manual addition.
+ *
+ * `reason` is restricted to the known union; the DB column is plain text
+ * for forward compatibility, but the API surface is strict so consumers
+ * can't drift the vocabulary.
+ *
+ * `expiresAt` is optional. When omitted, the suppression is permanent
+ * (the right default for `manual` and `complaint`).
+ */
+export const createSuppressionDto = t.Object({
+  /** Recipient address to suppress. */
+  email: t.String({ format: "email", maxLength: 255 }),
+
+  /**
+   * Why. `bounce` and `unsubscribe` are typically populated by automated
+   * paths (auto-suppression in #24, one-click unsubscribe endpoint in a
+   * future ticket); manual additions usually come in as `manual`.
+   */
+  reason: t.Union(
+    SUPPRESSION_REASONS.map((r) => t.Literal(r)),
+    { default: "manual" },
+  ),
+
+  /** ISO-8601 timestamp; null/omitted = permanent. */
+  expiresAt: t.Optional(t.Union([t.Date(), t.String({ format: "date-time" }), t.Null()])),
+});

--- a/src/modules/suppressions/dtos/list-suppressions.dto.ts
+++ b/src/modules/suppressions/dtos/list-suppressions.dto.ts
@@ -1,0 +1,16 @@
+import { t } from "elysia";
+
+/**
+ * Query parameters for `GET /api/v1/suppressions`.
+ *
+ * `email` is an exact-match filter (typed lookup) — useful when a
+ * dashboard wants to show "is this address suppressed?" without paging
+ * through the entire list. Wildcard / substring search is intentionally
+ * not supported: it would force a non-indexed scan, and the existing
+ * `(api_key_id, email)` index already makes exact match fast.
+ */
+export const listSuppressionsDto = t.Object({
+  page: t.Optional(t.Numeric({ minimum: 1, default: 1 })),
+  limit: t.Optional(t.Numeric({ minimum: 1, maximum: 100, default: 20 })),
+  email: t.Optional(t.String({ maxLength: 255 })),
+});

--- a/src/modules/suppressions/errors.ts
+++ b/src/modules/suppressions/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Thrown by `email.service.createEmail` when the recipient is on the
+ * suppression list for the calling API key. The global `.onError`
+ * handler in `src/index.ts` recognises this class and maps it to
+ * HTTP 422 with a structured body — without that handler, Elysia would
+ * default to 500.
+ *
+ * Carrying `suppressionId` in the body lets clients pivot directly to
+ * `DELETE /api/v1/suppressions/:id` when they want to undo (e.g. a
+ * recipient who confirmed they want emails again).
+ */
+export class SuppressedRecipientError extends Error {
+  override readonly name = "SuppressedRecipientError";
+  readonly suppressionId: string;
+  readonly recipient: string;
+
+  constructor(args: { suppressionId: string; recipient: string }) {
+    super(
+      `Recipient is on the suppression list. Remove the suppression first if this is intentional.`,
+    );
+    this.suppressionId = args.suppressionId;
+    this.recipient = args.recipient;
+  }
+}

--- a/src/modules/suppressions/models/suppression.schema.ts
+++ b/src/modules/suppressions/models/suppression.schema.ts
@@ -1,0 +1,111 @@
+import {
+  pgTable,
+  varchar,
+  text,
+  timestamp,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { apiKeys } from "../../api-keys/models/api-key.schema.ts";
+import { emails } from "../../emails/models/email.schema.ts";
+
+/**
+ * Suppression list — addresses we refuse to send to. Checked at the
+ * `createEmail` gate before queuing; sends to suppressed recipients
+ * are rejected with 422 and never reach the queue or the SMTP path.
+ *
+ * Scope: per `api_key_id`. Different API keys often represent different
+ * customer environments (transactional / marketing / dev), so one key's
+ * bounces should never gate another key's sends. Mirrors what
+ * SES / SendGrid / Resend do.
+ *
+ * Auto-suppression on bounces is the responsibility of #24 (DSN
+ * parsing); this module only provides the storage + lookup primitive
+ * and a public `addFromBounce()` service method that the future bounce
+ * handler will call.
+ */
+export const suppressions = pgTable(
+  "suppressions",
+  {
+    /** Unique identifier, prefixed with `sup_` (e.g. sup_a1b2c3...) */
+    id: varchar("id", { length: 36 }).primaryKey(),
+
+    /**
+     * Owning API key. Suppressions are per-tenant — see file header.
+     * `ON DELETE CASCADE` so revoked keys also drop their suppression
+     * lists; an inactive key shouldn't keep a suppression alive that
+     * a different key has to step around.
+     */
+    apiKeyId: varchar("api_key_id", { length: 36 })
+      .notNull()
+      .references(() => apiKeys.id, { onDelete: "cascade" }),
+
+    /** Recipient address that should never be sent to under this key. */
+    email: varchar("email", { length: 255 }).notNull(),
+
+    /**
+     * Why the address is suppressed. Lower-cased free text for forward
+     * compatibility — using a Postgres enum would force a migration on
+     * every new reason. Validated to one of the known values via the
+     * DTO at the API boundary; the DB stays open.
+     *
+     * Known values today: `bounce`, `complaint`, `manual`, `unsubscribe`.
+     */
+    reason: text("reason").notNull(),
+
+    /**
+     * For `reason = 'bounce'`, what kind. `hard` = permanent (mailbox
+     * doesn't exist, domain doesn't exist), `soft` = transient (mailbox
+     * full, recipient over quota). Null for non-bounce reasons.
+     *
+     * Populated by #24 (DSN parsing) when it lands.
+     */
+    bounceType: varchar("bounce_type", { length: 20 }),
+
+    /**
+     * Optional SMTP enhanced status code from the bounce DSN, e.g.
+     * "5.1.1" (no such user) or "4.2.2" (mailbox full). Useful for
+     * operators triaging deliverability without re-parsing the bounce.
+     */
+    diagnosticCode: text("diagnostic_code"),
+
+    /**
+     * The email row that triggered this suppression (the bounce came
+     * back for this `msg_...` send). `ON DELETE SET NULL` so trash
+     * purges don't break suppressions that should outlive them.
+     * Null for manually-added entries.
+     */
+    sourceEmailId: varchar("source_email_id", { length: 36 }).references(
+      () => emails.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+
+    /**
+     * Optional expiry. Null = permanent (the default for hard bounces
+     * and manual additions). Set for soft-bounce backoff entries that
+     * should auto-expire after some retention window.
+     */
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    /**
+     * One suppression per (api_key, email) — re-suppressing an address
+     * upserts the existing row rather than piling up duplicates. The
+     * service layer relies on this constraint for `ON CONFLICT DO UPDATE`.
+     */
+    uniqueIndex("suppressions_api_key_email_unique").on(table.apiKeyId, table.email),
+
+    /**
+     * Hot path — the `createEmail` gate runs `WHERE api_key_id = $1
+     * AND email = $2` on every send. The unique index above also serves
+     * this query, but Postgres composite uniques use a btree under the
+     * hood so this is effectively the same shape; the explicit index is
+     * documentation of intent.
+     */
+    index("suppressions_api_key_email_idx").on(table.apiKeyId, table.email),
+  ],
+);

--- a/src/modules/suppressions/serializations/suppression.serialization.ts
+++ b/src/modules/suppressions/serializations/suppression.serialization.ts
@@ -1,0 +1,30 @@
+import type { Suppression } from "../types/suppression.types.ts";
+
+/**
+ * Public response shape. Drops `apiKeyId` — the caller already knows
+ * which key they're scoped to (it's their own auth token), and exposing
+ * it back is needless noise. Everything else passes through unchanged.
+ */
+export interface SerializedSuppression {
+  id: string;
+  email: string;
+  reason: string;
+  bounceType: string | null;
+  diagnosticCode: string | null;
+  sourceEmailId: string | null;
+  expiresAt: Date | null;
+  createdAt: Date;
+}
+
+export function serializeSuppression(row: Suppression): SerializedSuppression {
+  return {
+    id: row.id,
+    email: row.email,
+    reason: row.reason,
+    bounceType: row.bounceType,
+    diagnosticCode: row.diagnosticCode,
+    sourceEmailId: row.sourceEmailId,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+  };
+}

--- a/src/modules/suppressions/services/suppression.service.ts
+++ b/src/modules/suppressions/services/suppression.service.ts
@@ -1,0 +1,223 @@
+import { and, eq, desc, gt, isNull, or, sql } from "drizzle-orm";
+import { db } from "../../../db/index.ts";
+import { suppressions } from "../models/suppression.schema.ts";
+import { generateId } from "../../../utils/id.ts";
+import { logger } from "../../../utils/logger.ts";
+import { redactEmail } from "../../../utils/redact.ts";
+import type {
+  Suppression,
+  CreateSuppressionInput,
+  AddFromBounceInput,
+} from "../types/suppression.types.ts";
+
+/**
+ * Lower-cases an address so the unique constraint behaves intuitively
+ * (`Alice@Example.com` and `alice@example.com` are the same recipient).
+ * RFC 5321 says the local part is technically case-sensitive, but
+ * essentially every modern receiver folds case, and matching that
+ * behaviour at suppression time avoids surprise bypasses.
+ */
+function normaliseEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Returns the active suppression row for a (apiKeyId, email) pair, or
+ * `undefined` if the recipient is allowed to receive mail. "Active"
+ * means the row exists and either has no expiry or the expiry is in
+ * the future.
+ *
+ * Hot path — runs on every send. The composite `(api_key_id, email)`
+ * index serves it; one btree probe.
+ */
+export async function isSuppressed(
+  apiKeyId: string,
+  email: string,
+): Promise<Suppression | undefined> {
+  const target = normaliseEmail(email);
+  const now = new Date();
+
+  const [row] = await db
+    .select()
+    .from(suppressions)
+    .where(
+      and(
+        eq(suppressions.apiKeyId, apiKeyId),
+        eq(suppressions.email, target),
+        /** Either permanent (expires_at IS NULL) or not yet expired. */
+        or(isNull(suppressions.expiresAt), gt(suppressions.expiresAt, now)),
+      ),
+    )
+    .limit(1);
+
+  return row;
+}
+
+/**
+ * Manual addition. Used by `POST /api/v1/suppressions`. Idempotent via
+ * `ON CONFLICT (api_key_id, email) DO UPDATE` — re-suppressing an
+ * address upserts the row, so a customer can update the reason or the
+ * expiry without first deleting.
+ *
+ * The bounce-specific fields (`bounceType`, `diagnosticCode`,
+ * `sourceEmailId`) are intentionally not exposed here; they're set by
+ * `addFromBounce` only, so manual requests can't fabricate fake DSN
+ * metadata.
+ */
+export async function createSuppression(
+  apiKeyId: string,
+  input: CreateSuppressionInput,
+): Promise<Suppression> {
+  const target = normaliseEmail(input.email);
+  const id = generateId("sup");
+
+  logger.info("Creating suppression", {
+    id,
+    apiKeyId,
+    email: redactEmail(target),
+    reason: input.reason,
+  });
+
+  const [row] = await db
+    .insert(suppressions)
+    .values({
+      id,
+      apiKeyId,
+      email: target,
+      reason: input.reason,
+      expiresAt: input.expiresAt ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [suppressions.apiKeyId, suppressions.email],
+      set: {
+        reason: input.reason,
+        expiresAt: input.expiresAt ?? null,
+        /**
+         * Manual upserts clear bounce-specific metadata — they didn't
+         * come from a DSN. Leaving stale fields would mislead operators.
+         */
+        bounceType: null,
+        diagnosticCode: null,
+        sourceEmailId: null,
+      },
+    })
+    .returning();
+
+  return row!;
+}
+
+/**
+ * Auto-suppression hook for the future bounce path (#24). Different
+ * shape from the manual `createSuppression` because we *want* the bounce
+ * metadata persisted here — operators triaging a deliverability issue
+ * need the diagnostic code + source email.
+ *
+ * Forces `reason = 'bounce'`. Idempotent — re-calling with a fresh
+ * bounce updates the existing row (later bounce wins). Exported so
+ * #24's DSN parser can call it directly.
+ */
+export async function addFromBounce(
+  apiKeyId: string,
+  input: AddFromBounceInput,
+): Promise<Suppression> {
+  const target = normaliseEmail(input.email);
+  const id = generateId("sup");
+
+  logger.info("Auto-suppressing from bounce", {
+    id,
+    apiKeyId,
+    email: redactEmail(target),
+    bounceType: input.bounceType,
+    diagnosticCode: input.diagnosticCode,
+  });
+
+  const [row] = await db
+    .insert(suppressions)
+    .values({
+      id,
+      apiKeyId,
+      email: target,
+      reason: "bounce",
+      bounceType: input.bounceType,
+      diagnosticCode: input.diagnosticCode ?? null,
+      sourceEmailId: input.sourceEmailId ?? null,
+      expiresAt: input.expiresAt ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [suppressions.apiKeyId, suppressions.email],
+      set: {
+        reason: "bounce",
+        bounceType: input.bounceType,
+        diagnosticCode: input.diagnosticCode ?? null,
+        sourceEmailId: input.sourceEmailId ?? null,
+        expiresAt: input.expiresAt ?? null,
+      },
+    })
+    .returning();
+
+  return row!;
+}
+
+/**
+ * Paginated list, scoped to one API key. `email` is exact-match — the
+ * indexed lookup serves both the gate and this query path.
+ */
+export async function listSuppressions(
+  apiKeyId: string,
+  filters: { page: number; limit: number; email?: string },
+): Promise<{ data: Suppression[]; total: number }> {
+  const offset = (filters.page - 1) * filters.limit;
+  const conditions = [eq(suppressions.apiKeyId, apiKeyId)];
+  if (filters.email) {
+    conditions.push(eq(suppressions.email, normaliseEmail(filters.email)));
+  }
+  const where = and(...conditions);
+
+  const [data, totalRows] = await Promise.all([
+    db
+      .select()
+      .from(suppressions)
+      .where(where)
+      .orderBy(desc(suppressions.createdAt))
+      .limit(filters.limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(suppressions)
+      .where(where),
+  ]);
+
+  return { data, total: totalRows[0]?.count ?? 0 };
+}
+
+/**
+ * Single-row read. Scoped — a key can only fetch its own suppressions,
+ * just like every other module's read paths.
+ */
+export async function getSuppressionById(
+  id: string,
+  apiKeyId: string,
+): Promise<Suppression | undefined> {
+  const [row] = await db
+    .select()
+    .from(suppressions)
+    .where(and(eq(suppressions.id, id), eq(suppressions.apiKeyId, apiKeyId)))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Hard delete. Scoped to the calling key. Returns the deleted row so
+ * the plugin can serialise it back, or `undefined` when nothing matched
+ * (the plugin maps that to 404).
+ */
+export async function deleteSuppression(
+  id: string,
+  apiKeyId: string,
+): Promise<Suppression | undefined> {
+  const [row] = await db
+    .delete(suppressions)
+    .where(and(eq(suppressions.id, id), eq(suppressions.apiKeyId, apiKeyId)))
+    .returning();
+  return row;
+}

--- a/src/modules/suppressions/suppressions.plugin.ts
+++ b/src/modules/suppressions/suppressions.plugin.ts
@@ -1,0 +1,146 @@
+import { Elysia, t } from "elysia";
+import { createSuppressionDto } from "./dtos/create-suppression.dto.ts";
+import { listSuppressionsDto } from "./dtos/list-suppressions.dto.ts";
+import { serializeSuppression } from "./serializations/suppression.serialization.ts";
+import * as suppressionService from "./services/suppression.service.ts";
+import { authMiddleware } from "../../middleware/auth.ts";
+import { rateLimitMiddleware } from "../../middleware/rate-limit.ts";
+import { logger } from "../../utils/logger.ts";
+import { redactEmail } from "../../utils/redact.ts";
+
+/**
+ * Suppression list plugin — addresses we refuse to send to.
+ *
+ * Routes (all auth-required, scoped to the calling API key):
+ * - POST   /                Manually add an address
+ * - GET    /                Paginated list, optional exact-match `email` filter
+ * - GET    /:id             Read one
+ * - DELETE /:id             Remove (allows re-sending to the recipient)
+ *
+ * The actual send-time gate lives in `email.service.createEmail` — when
+ * a recipient is on the list, that path throws `SuppressedRecipientError`
+ * which the global `onError` handler maps to HTTP 422.
+ */
+export const suppressionsPlugin = new Elysia({
+  prefix: "/api/v1/suppressions",
+  normalize: true,
+})
+  .use(authMiddleware)
+  .use(rateLimitMiddleware)
+
+  .post(
+    "/",
+    async ({ body, apiKeyId }) => {
+      logger.info("POST /api/v1/suppressions", {
+        apiKeyId,
+        email: redactEmail(body.email),
+        reason: body.reason,
+      });
+
+      const expiresAt =
+        body.expiresAt instanceof Date
+          ? body.expiresAt
+          : typeof body.expiresAt === "string"
+            ? new Date(body.expiresAt)
+            : null;
+
+      const row = await suppressionService.createSuppression(apiKeyId, {
+        email: body.email,
+        reason: body.reason,
+        expiresAt,
+      });
+
+      return { success: true, data: serializeSuppression(row) };
+    },
+    {
+      body: createSuppressionDto,
+      detail: {
+        tags: ["Suppressions"],
+        summary: "Add an address to the suppression list",
+        description:
+          "Idempotent — re-suppressing an existing address upserts the row. Subsequent sends to this recipient under this API key will return 422.",
+        security: [{ bearerAuth: [] }],
+      },
+    },
+  )
+
+  .get(
+    "/",
+    async ({ query, apiKeyId }) => {
+      logger.info("GET /api/v1/suppressions", { apiKeyId, ...query });
+
+      const { data, total } = await suppressionService.listSuppressions(apiKeyId, {
+        page: query.page ?? 1,
+        limit: query.limit ?? 20,
+        email: query.email,
+      });
+
+      return {
+        success: true,
+        data: data.map(serializeSuppression),
+        pagination: {
+          page: query.page ?? 1,
+          limit: query.limit ?? 20,
+          total,
+        },
+      };
+    },
+    {
+      query: listSuppressionsDto,
+      detail: {
+        tags: ["Suppressions"],
+        summary: "List suppressions",
+        description:
+          "Returns a paginated list of suppressed addresses for the current API key. Use the optional `email` query param for an exact-match lookup.",
+        security: [{ bearerAuth: [] }],
+      },
+    },
+  )
+
+  .get(
+    "/:id",
+    async ({ params, apiKeyId, set }) => {
+      logger.info("GET /api/v1/suppressions/:id", { apiKeyId, id: params.id });
+
+      const row = await suppressionService.getSuppressionById(params.id, apiKeyId);
+      if (!row) {
+        set.status = 404;
+        return { success: false, error: "Suppression not found" };
+      }
+
+      return { success: true, data: serializeSuppression(row) };
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      detail: {
+        tags: ["Suppressions"],
+        summary: "Get a suppression by ID",
+        security: [{ bearerAuth: [] }],
+      },
+    },
+  )
+
+  .delete(
+    "/:id",
+    async ({ params, apiKeyId, set }) => {
+      logger.info("DELETE /api/v1/suppressions/:id", { apiKeyId, id: params.id });
+
+      const row = await suppressionService.deleteSuppression(params.id, apiKeyId);
+      if (!row) {
+        set.status = 404;
+        return { success: false, error: "Suppression not found" };
+      }
+
+      return { success: true, data: serializeSuppression(row) };
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      detail: {
+        tags: ["Suppressions"],
+        summary: "Remove a suppression",
+        description:
+          "Hard-deletes the suppression. The recipient becomes eligible for sends from this API key again immediately.",
+        security: [{ bearerAuth: [] }],
+      },
+    },
+  );

--- a/src/modules/suppressions/types/suppression.types.ts
+++ b/src/modules/suppressions/types/suppression.types.ts
@@ -1,0 +1,51 @@
+import type { InferSelectModel } from "drizzle-orm";
+import type { suppressions } from "../models/suppression.schema.ts";
+
+/**
+ * Row shape returned from the database. Inferred from the Drizzle schema
+ * so renames stay in sync without a duplicate type definition.
+ */
+export type Suppression = InferSelectModel<typeof suppressions>;
+
+/**
+ * Reasons we accept at the API boundary. The DB column is plain text for
+ * forward compatibility — a finer split (e.g. `bounce.hard.no_user`) can
+ * land later without a migration. The API DTO restricts incoming reasons
+ * to this set so we don't grow stringly-typed accidentally.
+ */
+export const SUPPRESSION_REASONS = [
+  "bounce",
+  "complaint",
+  "manual",
+  "unsubscribe",
+] as const;
+export type SuppressionReason = (typeof SUPPRESSION_REASONS)[number];
+
+export const BOUNCE_TYPES = ["hard", "soft"] as const;
+export type BounceType = (typeof BOUNCE_TYPES)[number];
+
+/**
+ * Input accepted by the manual `POST /suppressions` endpoint. A subset
+ * of the schema columns — the bounce-specific fields are populated by
+ * the auto-suppression path (#24) only.
+ */
+export interface CreateSuppressionInput {
+  email: string;
+  reason: SuppressionReason;
+  expiresAt?: Date | null;
+}
+
+/**
+ * Input shape used internally by the auto-suppression hook (#24 will
+ * call this once DSN parsing lands). Kept separate from the public
+ * `CreateSuppressionInput` so manual requests can't spoof a "bounce"
+ * reason with diagnostic-code metadata they didn't actually parse.
+ */
+export interface AddFromBounceInput {
+  email: string;
+  bounceType: BounceType;
+  diagnosticCode?: string;
+  sourceEmailId?: string;
+  /** Soft-bounce backoff window. Defaults to permanent for hard bounces. */
+  expiresAt?: Date | null;
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 
-type IdPrefix = "msg" | "key" | "dom" | "whk" | "tpl" | "inb";
+type IdPrefix = "msg" | "key" | "dom" | "whk" | "tpl" | "inb" | "sup";
 
 /**
  * Generates a prefixed unique ID.

--- a/test/e2e/suppressions-api.test.ts
+++ b/test/e2e/suppressions-api.test.ts
@@ -1,0 +1,248 @@
+import { describe, test, expect, mock } from "bun:test";
+import { Elysia } from "elysia";
+
+/**
+ * E2E tests for the Suppressions API (/api/v1/suppressions).
+ *
+ * Same pattern as `emails-api.test.ts`: the suppression service is
+ * fully mocked so route handlers can be exercised end-to-end without
+ * a live DB. Auth + rate-limit middlewares are stubbed to inject a
+ * fixed `apiKeyId`.
+ */
+
+interface SerializedSuppression {
+  id: string;
+  email: string;
+  reason: string;
+  bounceType: string | null;
+  diagnosticCode: string | null;
+  sourceEmailId: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+interface SuppressionResponse {
+  success: boolean;
+  error?: string;
+  data: SerializedSuppression;
+}
+
+interface SuppressionListResponse {
+  success: boolean;
+  data: SerializedSuppression[];
+  pagination: { page: number; limit: number; total: number };
+}
+
+interface ErrorResponse {
+  success: false;
+  error: string;
+}
+
+mock.module("../../src/config.ts", () => ({
+  config: {
+    database: { url: "postgres://test:test@localhost/test" },
+    server: { port: 3000, host: "0.0.0.0" },
+    mail: { hostname: "localhost" },
+    dashboard: { password: "", sessionSecret: "test-secret" },
+    logLevel: "error",
+  },
+}));
+
+mock.module("../../src/utils/logger.ts", () => ({
+  logger: {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+  },
+}));
+
+mock.module("../../src/db/index.ts", () => ({
+  db: {},
+}));
+
+const mockSuppression = {
+  id: "sup_test123",
+  apiKeyId: "key_test",
+  email: "blocked@example.com",
+  reason: "manual",
+  bounceType: null,
+  diagnosticCode: null,
+  sourceEmailId: null,
+  expiresAt: null as Date | null,
+  createdAt: new Date("2026-05-01"),
+};
+
+const mockBounceSuppression = {
+  ...mockSuppression,
+  id: "sup_bounce456",
+  email: "bounced@example.com",
+  reason: "bounce",
+  bounceType: "hard",
+  diagnosticCode: "5.1.1",
+  sourceEmailId: "msg_origin",
+};
+
+mock.module("../../src/modules/suppressions/services/suppression.service.ts", () => ({
+  createSuppression: mock(() => Promise.resolve(mockSuppression)),
+  listSuppressions: mock(() =>
+    Promise.resolve({ data: [mockSuppression, mockBounceSuppression], total: 2 }),
+  ),
+  getSuppressionById: mock((id: string) =>
+    Promise.resolve(id === "sup_test123" ? mockSuppression : undefined),
+  ),
+  deleteSuppression: mock((id: string) =>
+    Promise.resolve(id === "sup_test123" ? mockSuppression : undefined),
+  ),
+  isSuppressed: mock(() => Promise.resolve(undefined)),
+  addFromBounce: mock(() => Promise.resolve(mockBounceSuppression)),
+}));
+
+mock.module("../../src/middleware/auth.ts", () => ({
+  authMiddleware: new Elysia({ name: "auth-middleware" }).derive(() => ({
+    apiKeyId: "key_test",
+    apiKeyName: "Test Key",
+  })),
+}));
+
+mock.module("../../src/middleware/rate-limit.ts", () => ({
+  rateLimitMiddleware: new Elysia({ name: "rate-limit-middleware" }),
+}));
+
+const { suppressionsPlugin } =
+  await import("../../src/modules/suppressions/suppressions.plugin.ts");
+
+const app = new Elysia().use(suppressionsPlugin);
+
+describe("Suppressions API E2E", () => {
+  describe("POST /api/v1/suppressions", () => {
+    test("creates a manual suppression and returns the serialized row", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test_key",
+          },
+          body: JSON.stringify({
+            email: "blocked@example.com",
+            reason: "manual",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as SuppressionResponse;
+      expect(body.success).toBe(true);
+      expect(body.data.id).toBe("sup_test123");
+      expect(body.data.email).toBe("blocked@example.com");
+      expect(body.data.reason).toBe("manual");
+      /** Public response should never carry the apiKeyId — it's the caller's own. */
+      expect("apiKeyId" in body.data).toBe(false);
+    });
+
+    test("rejects an invalid email format with 422", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test_key",
+          },
+          body: JSON.stringify({ email: "not-an-email", reason: "manual" }),
+        }),
+      );
+
+      expect(response.status).toBe(422);
+    });
+
+    test("rejects an unknown reason with 422", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test_key",
+          },
+          body: JSON.stringify({ email: "x@example.com", reason: "made-up" }),
+        }),
+      );
+
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("GET /api/v1/suppressions", () => {
+    test("returns paginated list with both rows", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions", {
+          method: "GET",
+          headers: { authorization: "Bearer test_key" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as SuppressionListResponse;
+      expect(body.success).toBe(true);
+      expect(body.data).toHaveLength(2);
+      expect(body.pagination.total).toBe(2);
+      expect(body.data[0]!.id).toBe("sup_test123");
+      expect(body.data[1]!.bounceType).toBe("hard");
+      expect(body.data[1]!.diagnosticCode).toBe("5.1.1");
+    });
+  });
+
+  describe("GET /api/v1/suppressions/:id", () => {
+    test("returns the row when it exists", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions/sup_test123", {
+          method: "GET",
+          headers: { authorization: "Bearer test_key" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as SuppressionResponse;
+      expect(body.data.id).toBe("sup_test123");
+    });
+
+    test("returns 404 when the row doesn't exist", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions/sup_missing", {
+          method: "GET",
+          headers: { authorization: "Bearer test_key" },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as ErrorResponse;
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("DELETE /api/v1/suppressions/:id", () => {
+    test("removes an existing suppression and returns the deleted row", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions/sup_test123", {
+          method: "DELETE",
+          headers: { authorization: "Bearer test_key" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as SuppressionResponse;
+      expect(body.data.id).toBe("sup_test123");
+    });
+
+    test("returns 404 when nothing matches", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/suppressions/sup_missing", {
+          method: "DELETE",
+          headers: { authorization: "Bearer test_key" },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #25.

A suppression list — addresses BunMail refuses to send to. Repeated sends to bouncing recipients are the fastest way to kill IP reputation; this is the gate that stops it.

`POST /api/v1/emails/send` now checks the calling key's suppression list **before any other work**. Suppressed recipients return:

```http
HTTP/1.1 422 Unprocessable Entity
{ "success": false, "error": "...", "code": "RECIPIENT_SUPPRESSED", "suppressionId": "sup_..." }
```

The email is **not** inserted into `emails`, **not** queued, **not** attempted via SMTP. Hard-fail before any side effect.

## Decisions made

- **Per-API-key scoping** — different keys often represent different environments (transactional / marketing / dev), so one key's bounces shouldn't gate another's sends. Mirrors SES / SendGrid / Resend.
- **Address normalisation** — the gate folds case and trims whitespace before lookup (`Alice@Example.COM` → `alice@example.com`). RFC 5321 says local part is technically case-sensitive but every modern receiver folds, and matching that at the gate avoids surprise bypasses.
- **Auto-suppression NOT in this PR** — that needs DSN parsing (#24) to classify hard vs soft vs transient. The current retry path doesn't auto-suppress on `MAX_ATTEMPTS` exhaustion because crude rules would block legitimate transient failures. Internal `addFromBounce()` service method exposed so #24 can call it once parsing lands.
- **No `unsubscribe` endpoint yet** — Gmail Feb-2024 one-click List-Unsubscribe-Post needs its own ticket; the DB column accepts the `unsubscribe` reason today but no endpoint sets it.
- **No HTML branch in onError** — `SuppressedRecipientError` only fires from `createEmail`, called from the API plugin (always JSON consumers) and the dashboard's `/dashboard/send` form (which has its own try/catch + flash-message redirect). No browser-direct hits.

## Files

| File | Change |
|---|---|
| [src/modules/suppressions/](src/modules/suppressions/) | New module — schema, types, DTOs, serialization, error class, service, plugin |
| [src/db/schema.ts](src/db/schema.ts) | Re-export the new `suppressions` table for drizzle-kit |
| [drizzle/0003_nifty_phantom_reporter.sql](drizzle/0003_nifty_phantom_reporter.sql) | New migration — picked up by the bun-native runtime migrator on next boot |
| [src/utils/id.ts](src/utils/id.ts) | Add `"sup"` to the `IdPrefix` union |
| [src/modules/emails/services/email.service.ts](src/modules/emails/services/email.service.ts) | Run the suppression gate at the top of `createEmail` |
| [src/index.ts](src/index.ts) | Register the plugin; map `SuppressedRecipientError` → 422 in the global `onError` handler; add OpenAPI tag |
| [test/e2e/suppressions-api.test.ts](test/e2e/suppressions-api.test.ts) | 8 new tests covering full CRUD + DTO validation rejections |
| [docs/suppressions.md](docs/suppressions.md), [docs/api.md](docs/api.md), [README.md](README.md), [CHANGELOG.md](CHANGELOG.md) | Documentation |

## Schema

```
id              varchar(36) PK
api_key_id      varchar(36) FK api_keys(id) ON DELETE CASCADE
email           varchar(255)            -- normalised lower-case + trimmed
reason          text                    -- 'bounce' | 'complaint' | 'manual' | 'unsubscribe'
bounce_type     varchar(20)             -- 'hard' | 'soft' | null
diagnostic_code text                    -- e.g. '5.1.1'
source_email_id varchar(36) FK emails(id) ON DELETE SET NULL
expires_at      timestamptz             -- null = permanent
created_at      timestamptz default now()

UNIQUE  (api_key_id, email)
INDEX   (api_key_id, email)             -- gate hot-path
```

## API

| Method | Path | Notes |
|---|---|---|
| `POST` | `/api/v1/suppressions` | Idempotent — re-suppressing upserts via `ON CONFLICT (api_key_id, email) DO UPDATE` |
| `GET` | `/api/v1/suppressions` | Paginated; optional exact-match `?email=` filter |
| `GET` | `/api/v1/suppressions/:id` | 404 when missing or owned by a different key |
| `DELETE` | `/api/v1/suppressions/:id` | Recipient becomes eligible immediately |

Full request/response shapes in [docs/api.md](docs/api.md#suppressions).

## Local validation

- [x] `bunx tsc --noEmit` clean
- [x] `bun test test/unit` — 107 pass
- [x] `bun test test/e2e` — 70 pass (+8 new)
- [x] `bun run lint` clean
- [x] Migration generated cleanly via `bun run db:generate`

## Test plan

- [ ] CI green.
- [ ] After merge, on staging:
  - `git pull && docker compose up -d --build` — confirm migrator logs `Applying migration tag=0003_nifty_phantom_reporter`
  - `POST /api/v1/suppressions` with `{ "email": "test@example.com", "reason": "manual" }` — confirm 200 + serialized row
  - `POST /api/v1/emails/send` to that recipient — confirm 422 + `code: "RECIPIENT_SUPPRESSED"` and **no** row inserted into `emails`
  - `DELETE /api/v1/suppressions/:id` — confirm 200, then re-send to the same recipient and confirm normal queueing

## Out of scope (separate tickets)

- Auto-suppression on bounces → #24 (will call `addFromBounce()` once DSN parsing lands)
- One-click unsubscribe endpoint (Gmail Feb-2024 List-Unsubscribe-Post)
- FBL complaint ingestion
- Dashboard UI for managing suppressions
- Bulk import / CSV upload
- Auto-purge of expired rows