### PR TITLE
feat(dashboard): add bounced status filter to emails list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Bounced status filter in dashboard.** The emails list page now shows a "Bounced" filter tab alongside All / Queued / Sending / Sent / Failed. The `StatusBadge` component renders bounced emails with an orange pill. Closes #83.
+
 ### Fixed
 
 - **Trivy image scan failing on stale OS packages.** The `apt-get upgrade` layer in the Dockerfile was cached by GHA Docker layer caching, so Debian security patches (e.g. `libcap2`, `libsystemd0`) released after the last uncached build were never picked up. Added an `ARG APT_CACHE_BUST` set to `github.run_id` so every CI run builds a fresh apt layer. Install + prod-deps stages remain cached.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,7 +26,7 @@ If `DASHBOARD_PASSWORD` is not set, all dashboard routes show a "Dashboard disab
 | GET /dashboard/login             | Login form (standalone, no nav)                                   |
 | GET /dashboard                   | Stats overview — outbound, inbound, configuration sections        |
 | GET /dashboard/send              | Compose & send emails from dashboard                              |
-| GET /dashboard/emails            | Email logs with status filters, bulk-select, per-row trash        |
+| GET /dashboard/emails            | Email logs with status filters (All / Queued / Sending / Sent / Failed / Bounced), bulk-select, per-row trash |
 | GET /dashboard/emails/trash      | Trashed emails — bulk Restore / Delete-forever / Empty trash      |
 | GET /dashboard/emails/:id        | Single email detail + preview (Restore/Delete-forever if trashed) |
 | GET /dashboard/api-keys          | API keys list + create form                                       |

--- a/src/pages/components/status-badge.tsx
+++ b/src/pages/components/status-badge.tsx
@@ -9,6 +9,7 @@ export function StatusBadge({ status }: { status: string }) {
     queued: "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
     sending: "bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
     failed: "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300",
+    bounced: "bg-orange-50 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
   };
 
   const colorClass =

--- a/src/pages/pages.plugin.tsx
+++ b/src/pages/pages.plugin.tsx
@@ -4,6 +4,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { config } from "../config.ts";
 import { logger } from "../utils/logger.ts";
 import { redactEmail } from "../utils/redact.ts";
+import type { EmailStatus } from "../modules/emails/types/email.types.ts";
 
 /* ─── Page Components ─── */
 import { LoginPage, DashboardDisabledPage } from "./routes/login.tsx";
@@ -368,7 +369,7 @@ export const pagesPlugin = new Elysia({
       const { data, total } = await emailService.listAllEmails({
         page,
         limit,
-        status: status as "queued" | "sending" | "sent" | "failed" | undefined,
+        status: status as EmailStatus | undefined,
       });
 
       const flash = query.flash

--- a/src/pages/routes/emails.tsx
+++ b/src/pages/routes/emails.tsx
@@ -43,6 +43,7 @@ export function EmailsPage({
     { label: "Sending", value: "sending" },
     { label: "Sent", value: "sent" },
     { label: "Failed", value: "failed" },
+    { label: "Bounced", value: "bounced" },
   ];
 
   return (


### PR DESCRIPTION
## Summary

- Add "Bounced" filter tab to the dashboard emails list page (orange pill, consistent with the existing status tab pattern)
- Add orange color mapping for `bounced` in the `StatusBadge` component
- Fix the type cast in the dashboard route to use `EmailStatus` instead of a hardcoded union that omitted `bounced`
- Update `docs/dashboard.md` to enumerate all filter tabs explicitly
- Add `CHANGELOG.md` entry under `[Unreleased]`

Closes #83

## Test plan

- [x] Navigate to `/dashboard/emails` — verify 6 tabs: All, Queued, Sending, Sent, Failed, Bounced
- [x] Click the "Bounced" tab — verify it filters to only bounced emails and the tab is highlighted
- [x] Verify bounced emails show an orange status badge in the table
- [x] Verify pagination preserves the `?status=bounced` query param
- [x] Verify the other filter tabs still work as before


