### PR TITLE
fix(docker): parameterise PORT and SMTP_PORT in docker-compose.yml

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -813,7 +813,7 @@ BunMail sends emails directly to recipient MX servers using Nodemailer's `direct
 services:
   app:
     build: .
-    ports: ["3000:3000"]
+    ports: ["${PORT:-3000}:${PORT:-3000}"]
     environment:
       DATABASE_URL: postgres://bunmail:bunmail@db:5432/bunmail
       DKIM_ENCRYPTION_KEY: ${DKIM_ENCRYPTION_KEY}    # Required (#23) — `openssl rand -base64 32`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Docker port mappings now read from `.env`.** `PORT` and `SMTP_PORT` in `docker-compose.yml` are parameterised (`${PORT:-3000}`, `${SMTP_PORT:-25}`) so operators no longer need to edit two files when changing ports. Closes #92.
+
 - **Trivy image scan failing on stale OS packages.** The `apt-get upgrade` layer in the Dockerfile was cached by GHA Docker layer caching, so Debian security patches (e.g. `libcap2`, `libsystemd0`) released after the last uncached build were never picked up. Added an `ARG APT_CACHE_BUST` set to `github.run_id` so every CI run builds a fresh apt layer. Install + prod-deps stages remain cached.
 
 ## [0.5.0] - 2026-05-10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
   app:
     build: .
     ports:
-      - "3000:3000" # HTTP API + Dashboard
-      - "25:25" # Inbound SMTP (set SMTP_PORT=25 in .env)
+      - "${PORT:-3000}:${PORT:-3000}" # HTTP API + Dashboard
+      - "${SMTP_PORT:-25}:${SMTP_PORT:-25}" # Inbound SMTP (enable with SMTP_ENABLED=true)
     env_file: .env
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-bunmail}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-bunmail}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -135,9 +135,11 @@ docker compose up -d --build
 ```
 
 This starts:
-- **BunMail** on port 3000 (HTTP API + Dashboard)
+- **BunMail** on port `$PORT` (HTTP API + Dashboard, default 3000)
 - **PostgreSQL** on port 5432 (internal only)
-- **Inbound SMTP** on port 25 (if `SMTP_ENABLED=true`)
+- **Inbound SMTP** on port `$SMTP_PORT` (default 2525; use 25 in production — requires `SMTP_ENABLED=true`)
+
+Port mappings in `docker-compose.yml` read `PORT` and `SMTP_PORT` from `.env` automatically — if you change them in `.env`, you don't need to edit anything else.
 
 Migrations run automatically on boot. Verify with:
 
@@ -148,8 +150,8 @@ docker compose ps
 # Check logs
 docker compose logs app
 
-# Check health
-curl http://localhost:3000/health
+# Check health (use your PORT value)
+curl http://localhost:${PORT:-3000}/health
 ```
 
 ## 4. Initial Setup


### PR DESCRIPTION
## Summary

- Parameterise port mappings in `docker-compose.yml` using `${PORT:-3000}` and `${SMTP_PORT:-25}` so operators only need to edit `.env` when changing ports.
- Update `docs/self-hosting.md` to document that port changes propagate automatically.
- Update `ARCHITECTURE.md` snippet to match.

Closes #92

## Test plan

- [x] Set `PORT=8080` in `.env`, run `docker compose config` — verify host mapping shows `8080:8080`
- [x] Set `SMTP_PORT=2525` in `.env`, run `docker compose config` — verify SMTP mapping shows `2525:2525`
- [x] Remove both from `.env`, run `docker compose config` — verify defaults `3000:3000` and `25:25`

