### PR TITLE
fix(inbound): make SMTP receiver loudly opt-in instead of silently disabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,13 @@ MAIL_HOSTNAME=mail.example.com
 
 # ── Inbound SMTP Server ──
 # Set to "true" to enable the inbound SMTP server for receiving emails.
+# When using Docker Compose, you ALSO need to uncomment the inbound SMTP
+# port line in docker-compose.yml — otherwise the host port isn't bound
+# and external senders get "connection refused". See docs/inbound.md.
 SMTP_ENABLED=false
-# Port for the inbound SMTP server (default 2525; use 25 in production with proper permissions)
+# Port for the inbound SMTP server. Use 25 in production with Docker
+# (the container runs as root and can bind low ports); 2525 is the
+# local-dev default for non-root environments.
 SMTP_PORT=2525
 
 # ── SMTP Spam Protection ──

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Inbound SMTP receiver is now loudly opt-in.** Previously `SMTP_ENABLED=false` (the default) silently disabled the receiver while `docker-compose.yml` still bound host port 25 — operators following the README ended up with MX records pointing at a port nothing was listening on, with no log line to explain why. The inbound port line in `docker-compose.yml` is now commented out by default with the enable instructions inline, and the app logs `Inbound SMTP receiver disabled — set SMTP_ENABLED=true …` at startup whenever inbound is off. `.env.example` and `docs/inbound.md` carry a first-boot checklist that calls out the three knobs (env, compose, DNS) that have to agree. Closes #93.
 - **Docker port mappings now read from `.env`.** `PORT` and `SMTP_PORT` in `docker-compose.yml` are parameterised (`${PORT:-3000}`, `${SMTP_PORT:-25}`) so operators no longer need to edit two files when changing ports. Closes #92.
 
 - **Trivy image scan failing on stale OS packages.** The `apt-get upgrade` layer in the Dockerfile was cached by GHA Docker layer caching, so Debian security patches (e.g. `libcap2`, `libsystemd0`) released after the last uncached build were never picked up. Added an `ARG APT_CACHE_BUST` set to `github.run_id` so every CI run builds a fresh apt layer. Install + prod-deps stages remain cached.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     build: .
     ports:
       - "${PORT:-3000}:${PORT:-3000}" # HTTP API + Dashboard
-      - "${SMTP_PORT:-25}:${SMTP_PORT:-25}" # Inbound SMTP (enable with SMTP_ENABLED=true)
+      # Inbound SMTP is OFF by default. To enable: (1) uncomment the line below,
+      # (2) set SMTP_ENABLED=true and SMTP_PORT=25 in your .env. See docs/inbound.md.
+      # - "${SMTP_PORT:-25}:${SMTP_PORT:-25}"
     env_file: .env
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-bunmail}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-bunmail}

--- a/docs/inbound.md
+++ b/docs/inbound.md
@@ -53,6 +53,16 @@ Table: `inbound_emails`
 
 In production, set `SMTP_PORT=25` and configure your domain's MX record to point to your server.
 
+### First-boot checklist (Docker Compose)
+
+Inbound is **off by default** — sending-only is the common use case, and an open SMTP receiver is a footgun if it isn't configured deliberately. To turn it on with Docker Compose, three things have to agree:
+
+1. **`.env`**: set `SMTP_ENABLED=true` and `SMTP_PORT=25`.
+2. **`docker-compose.yml`**: uncomment the inbound SMTP port line under `services.app.ports`. It's commented out by default so a fresh checkout doesn't try to bind host port 25 unexpectedly.
+3. **DNS**: add an `MX` record for your domain pointing at the host running BunMail.
+
+Then `docker compose up -d --build`. From outside the host, verify with `nc -zv <your-host> 25` — the connection should be accepted. If it isn't, check `docker compose logs app` for the line `Inbound SMTP receiver disabled` — that means step 1 wasn't picked up.
+
 ## Spam Protection
 
 Three layers of protection run before any email is processed. All are enabled by default.

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,10 +201,18 @@ queueService.start();
 
 /**
  * Start the inbound SMTP server (if enabled).
- * Listens for incoming emails and stores them in the database.
+ *
+ * Inbound is opt-in (`SMTP_ENABLED=true`). When it's off we log an
+ * explicit info line so the silent-fail mode — "I set up MX records
+ * but nothing arrives" — is one `grep` away from a diagnosis instead
+ * of a head-scratch. (#93)
  */
 if (config.smtp.enabled) {
   smtpReceiver.start();
+} else {
+  logger.info(
+    "Inbound SMTP receiver disabled — set SMTP_ENABLED=true (and uncomment the SMTP port line in docker-compose.yml) to enable",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #93.

Three small changes that convert the inbound-SMTP first-boot experience from "silent fail" into "loud opt-in":

- **`docker-compose.yml`** — comment out the inbound SMTP port mapping by default with the enable steps inline. Outbound-only operators (the majority) no longer bind host port 25 they don't need.
- **`src/index.ts`** — when `SMTP_ENABLED=false`, log an explicit info line at startup so the silent-fail mode ("I set up MX records but nothing arrives") becomes one `grep` away from a diagnosis.
- **`docs/inbound.md` + `.env.example`** — first-boot checklist calling out the three knobs (env, compose, DNS) that have to agree to receive mail.

## Why this instead of default-on

Defaulting `SMTP_ENABLED=true` was on the table but rejected: many self-hosters use BunMail outbound-only (a SendGrid-style API), an open SMTP receiver without recipient validation tuning is an abuse surface, and some VPS hosts block port 25 entirely. Opt-in stays the safe default — the failure mode just needs to be visible instead of silent.

## Changes

- `docker-compose.yml` — SMTP port line commented out by default with inline enable instructions.
- `src/index.ts` — info-level log when inbound is disabled, naming both knobs that have to change.
- `.env.example` — `SMTP_ENABLED` and `SMTP_PORT` comments now mention the docker-compose line that must also be uncommented.
- `docs/inbound.md` — "First-boot checklist (Docker Compose)" section under Configuration.
- `CHANGELOG.md` — entry under `[Unreleased] / Fixed`.

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bun test test/unit` (256 pass)
- [x] `bun test test/e2e` (70 pass)
- [x] `bun test:integration` (89 pass)
- [x] `bun run lint`
- [ ] Manual smoke: fresh `.env`, `docker compose up -d --build` → `docker compose logs app` shows the `Inbound SMTP receiver disabled` line; `nc -zv localhost 25` returns connection refused. Set `SMTP_ENABLED=true`, `SMTP_PORT=25`, uncomment the compose line, rebuild → `nc -zv localhost 25` succeeds.