### PR TITLE
fix(dashboard): timestamps render in viewer machine time, never date-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dashboard timestamps now render in the viewer's machine time** with relative phrasing (#104). Every server-rendered date was previously formatted in the server's timezone (UTC in Docker) and locale (`en-US`), and many places dropped the time entirely (`toLocaleDateString()`). A shared `<TimeDisplay>` component now emits a semantic `<time datetime>` tag; one hydration script in `BaseLayout` rewrites every such element on load to relative time (`5m ago`, `Yesterday 14:32`, `Jan 5, 14:32`) using `Intl.DateTimeFormat` in the browser's locale + timezone. The `title` tooltip carries the full absolute timestamp with timezone. The dashboard never shows a bare date anymore — every rendered value carries date and time together.
+
 ## [0.6.0] - 2026-05-25
 
 > **Theme: multi-MX delivery + dashboard polish.** Cross-domain CC/BCC actually works now. The mailer parses recipients, groups by destination MX, and opens one SMTP session per group (with envelope override) so each receiver sees RCPT TO for only its own addresses — same DKIM-signed body, same canonical `Message-ID:` across all groups. Mixed-outcome rows retry only the groups that need it via a new per-group `delivery_state` JSONB column on `emails`, with no duplicate sends to groups that already succeeded. The outbound queue gains a per-MX semaphore (#91) so strict receivers stop 421-ing parallel sessions. Inbound SMTP is now loudly opt-in (#93) instead of silently disabled. The dashboard ships three new pieces: Gmail-style chip input for CC/BCC (#85), reply on inbound emails (#86), and an admin-scoped suppressions list with an explicit "Sending as" key picker (#89). Docker-compose port mappings are now `.env`-driven (#92).

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -78,8 +78,34 @@ src/pages/
     ├── status-badge.tsx      ← Status + verification badges
     ├── pagination.tsx        ← Page navigation
     ├── flash-message.tsx     ← Success/error banners
-    └── empty-state.tsx       ← Empty table placeholder
+    ├── empty-state.tsx       ← Empty table placeholder
+    └── time-display.tsx      ← <TimeDisplay> + hydration script (#104)
 ```
+
+## Timestamps
+
+Every timestamp on the dashboard goes through `<TimeDisplay value={date} />`
+([src/pages/components/time-display.tsx](../src/pages/components/time-display.tsx)).
+The server renders a `<time datetime>` element with a static UTC fallback;
+a single hydration script in `BaseLayout` rewrites every such element on
+load with relative-time text (`5m ago`, `Yesterday 14:32`, `Jan 5, 14:32`,
+`Jan 5, 2024, 14:32`) in the **viewer's browser locale + timezone**.
+
+The full absolute timestamp is always available via the `title` tooltip.
+The component intentionally exposes no date-only format — the dashboard
+never shows a bare date; every rendered value carries date and time.
+
+When adding a new dashboard route that displays a timestamp:
+
+```tsx
+import { TimeDisplay } from "../components/time-display.tsx";
+
+<TimeDisplay value={row.createdAt} />               // most cases
+<TimeDisplay value={key.lastUsedAt} fallback="Never" />  // null-safe
+```
+
+Do not call `toLocaleString()` / `toLocaleDateString()` / `toISOString()`
+directly in JSX — those run on the server and bake in the server's tz/locale.
 
 ## Form Actions
 

--- a/src/pages/components/time-display.tsx
+++ b/src/pages/components/time-display.tsx
@@ -1,0 +1,142 @@
+/**
+ * Shared date/time formatter for the dashboard. (#104)
+ *
+ * The dashboard is server-rendered by a Bun process whose locale and
+ * timezone are the *machine's*, not the viewer's. In production
+ * (Docker) that almost always means UTC + `en-US`. Calling
+ * `toLocaleString()` on the server would burn that in. To render in
+ * the viewer's machine time we punt formatting to the browser:
+ *
+ *   - Server emits `<time datetime="<iso>" data-bm-time>` with a
+ *     static UTC fallback as text content.
+ *   - {@link TimeDisplayScript} (injected once via BaseLayout) walks
+ *     every such element on load and rewrites:
+ *       • `textContent` → relative time (`5m ago`, `Yesterday 14:32`,
+ *         `Jan 5, 14:32`, `Jan 5, 2024, 14:32`) in the browser's
+ *         locale + timezone.
+ *       • `title` → full absolute timestamp with timezone, so a
+ *         hover always reveals the exact wall-clock value.
+ *
+ * Design rule: every rendered string carries BOTH date and time
+ * (relative phrasings like "5m ago" inherently encode both). There
+ * is intentionally no date-only format — the dashboard never shows
+ * a bare date.
+ *
+ * Usage:
+ *
+ *   <TimeDisplay value={email.createdAt} />                  // relative + absolute hover
+ *   <TimeDisplay value={key.lastUsedAt} fallback="Never" />  // null-safe
+ */
+
+interface TimeDisplayProps {
+  /** Timestamp to render. Null/undefined → fallback string. */
+  value: Date | null | undefined;
+  /** Text to show when value is null/undefined. Defaults to `—`. */
+  fallback?: string;
+  /** Optional Tailwind classes piped to the `<time>` element. */
+  class?: string;
+}
+
+export function TimeDisplay({
+  value,
+  fallback = "—",
+  class: className,
+}: TimeDisplayProps) {
+  if (!value) return fallback;
+  const iso = value.toISOString();
+  /** Pre-hydration fallback — full UTC date + time, unambiguous. */
+  const utcFallback = `${iso.slice(0, 16).replace("T", " ")} UTC`;
+  return (
+    <time datetime={iso} data-bm-time="" title={iso} class={className} safe>
+      {utcFallback}
+    </time>
+  );
+}
+
+/**
+ * Hydration script — emitted ONCE per page (via BaseLayout). Walks
+ * every `<time data-bm-time>` element after parse and rewrites its
+ * textContent to a relative-time phrase ("5m ago", "Yesterday 14:32",
+ * "Jan 5, 14:32") in the viewer's locale + timezone, while the
+ * `title` attribute carries the full absolute timestamp.
+ *
+ * Runs synchronously at end-of-body so the DOM is already populated;
+ * no DOMContentLoaded listener needed. Locale `undefined` =
+ * browser default. Timezone is inferred by `Intl.DateTimeFormat`
+ * from the host machine.
+ *
+ * The script is also re-runnable: if future code dynamically injects
+ * new `<time data-bm-time>` elements (none today), call
+ * `window.bmHydrateTimes()` to refresh them.
+ */
+export function TimeDisplayScript() {
+  return (
+    <script>
+      {`
+        (function() {
+          function fmtAbsolute(d, now, withYear) {
+            return new Intl.DateTimeFormat(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: withYear ? 'numeric' : undefined,
+              hour: '2-digit',
+              minute: '2-digit'
+            }).format(d);
+          }
+          function fmtTime(d) {
+            return new Intl.DateTimeFormat(undefined, {
+              hour: '2-digit', minute: '2-digit'
+            }).format(d);
+          }
+          function fmtTooltip(d) {
+            return new Intl.DateTimeFormat(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+              timeZoneName: 'short'
+            }).format(d);
+          }
+          function relative(d, now) {
+            var diffMs = now.getTime() - d.getTime();
+            /** Future dates: skip relative, show absolute. */
+            if (diffMs < 0) {
+              return fmtAbsolute(d, now, d.getFullYear() !== now.getFullYear());
+            }
+            var diffSec = Math.floor(diffMs / 1000);
+            if (diffSec < 60) return 'just now';
+            var diffMin = Math.floor(diffSec / 60);
+            if (diffMin < 60) return diffMin + 'm ago';
+            var diffHr = Math.floor(diffMin / 60);
+            if (diffHr < 24) return diffHr + 'h ago';
+            var diffDay = Math.floor(diffHr / 24);
+            if (diffDay === 1) return 'Yesterday ' + fmtTime(d);
+            if (diffDay < 7) {
+              return new Intl.DateTimeFormat(undefined, {
+                weekday: 'short', hour: '2-digit', minute: '2-digit'
+              }).format(d);
+            }
+            return fmtAbsolute(d, now, d.getFullYear() !== now.getFullYear());
+          }
+          function hydrate() {
+            var now = new Date();
+            document.querySelectorAll('time[data-bm-time]').forEach(function(el) {
+              var iso = el.getAttribute('datetime');
+              if (!iso) return;
+              var d = new Date(iso);
+              if (isNaN(d.getTime())) return;
+              try {
+                el.textContent = relative(d, now);
+                el.setAttribute('title', fmtTooltip(d));
+              } catch (e) { /** Locale failure — leave server fallback. */ }
+            });
+          }
+          window.bmHydrateTimes = hydrate;
+          hydrate();
+        })();
+      `}
+    </script>
+  );
+}

--- a/src/pages/layouts/base.tsx
+++ b/src/pages/layouts/base.tsx
@@ -13,6 +13,7 @@ import {
   ThemeIcon,
   LogoutIcon,
 } from "../assets/icons.tsx";
+import { TimeDisplayScript } from "../components/time-display.tsx";
 
 /**
  * Props for the base HTML layout shell.
@@ -95,6 +96,8 @@ export function BaseLayout({
             });
           `}
         </script>
+        {/* Hydrate every <time data-bm-time> into the viewer's locale + timezone (#104). */}
+        <TimeDisplayScript />
       </body>
     </html>
   );

--- a/src/pages/routes/api-keys.tsx
+++ b/src/pages/routes/api-keys.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { ApiKey } from "../../modules/api-keys/types/api-key.types.ts";
 
 /**
@@ -107,10 +108,10 @@ export function ApiKeysPage({ keys, flash, rawKey }: ApiKeysPageProps) {
                     )}
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {key.lastUsedAt ? key.lastUsedAt.toLocaleDateString() : "Never"}
+                    <TimeDisplay value={key.lastUsedAt} fallback="Never" />
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {key.createdAt.toLocaleDateString()}
+                    <TimeDisplay value={key.createdAt} />
                   </td>
                   <td class="px-4 py-3">
                     {key.isActive && (

--- a/src/pages/routes/dmarc-report-detail.tsx
+++ b/src/pages/routes/dmarc-report-detail.tsx
@@ -1,4 +1,5 @@
 import { BaseLayout } from "../layouts/base.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type {
   DmarcReport,
   DmarcRecord,
@@ -44,9 +45,9 @@ export function DmarcReportDetailPage({ report, records }: DmarcReportDetailPage
       <h1 class="text-xl font-semibold mb-1">{report.orgName}</h1>
       <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
         Report for <span class="font-mono">{report.domain}</span> ·{" "}
-        {report.dateBegin.toISOString().slice(0, 10)} →{" "}
-        {report.dateEnd.toISOString().slice(0, 10)} · policy{" "}
-        <span class="font-mono">p={report.policyP}</span> (pct={report.policyPct})
+        <TimeDisplay value={report.dateBegin} /> → <TimeDisplay value={report.dateEnd} />{" "}
+        · policy <span class="font-mono">p={report.policyP}</span> (pct={report.policyPct}
+        )
       </p>
 
       {/* Summary cards */}

--- a/src/pages/routes/dmarc-reports.tsx
+++ b/src/pages/routes/dmarc-reports.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { Pagination } from "../components/pagination.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { DmarcReport } from "../../modules/dmarc-reports/types/dmarc-report.types.ts";
 
 interface DmarcReportsPageProps {
@@ -107,8 +108,8 @@ export function DmarcReportsPage({
                   </td>
                   <td class="px-4 py-3 font-mono text-xs">{r.domain}</td>
                   <td class="px-4 py-3 text-gray-600 dark:text-gray-400 text-xs">
-                    {r.dateBegin.toISOString().slice(0, 10)} →{" "}
-                    {r.dateEnd.toISOString().slice(0, 10)}
+                    <TimeDisplay value={r.dateBegin} /> →{" "}
+                    <TimeDisplay value={r.dateEnd} />
                   </td>
                   <td class="px-4 py-3">
                     <span class="px-2 py-0.5 text-xs rounded bg-gray-100 dark:bg-gray-800">
@@ -116,7 +117,7 @@ export function DmarcReportsPage({
                     </span>
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">
-                    {r.receivedAt.toISOString().slice(0, 16).replace("T", " ")}
+                    <TimeDisplay value={r.receivedAt} />
                   </td>
                 </tr>
               ))}

--- a/src/pages/routes/domain-detail.tsx
+++ b/src/pages/routes/domain-detail.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { VerificationBadge } from "../components/status-badge.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import { BackArrowIcon } from "../assets/icons.tsx";
 import { getDkimDnsRecord } from "../../modules/domains/services/domain.service.ts";
 import type { Domain } from "../../modules/domains/types/domain.types.ts";
@@ -92,9 +93,23 @@ export function DomainDetailPage({ domain, flash }: DomainDetailPageProps) {
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
           <DetailField label="ID" value={domain.id} />
           <DetailField label="DKIM Selector" value={domain.dkimSelector} />
-          <DetailField label="Created" value={domain.createdAt.toISOString()} />
+          <div>
+            <p class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide mb-0.5">
+              Created
+            </p>
+            <p class="text-gray-900 dark:text-gray-100 break-all">
+              <TimeDisplay value={domain.createdAt} />
+            </p>
+          </div>
           {domain.verifiedAt && (
-            <DetailField label="Last Verified" value={domain.verifiedAt.toISOString()} />
+            <div>
+              <p class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide mb-0.5">
+                Last Verified
+              </p>
+              <p class="text-gray-900 dark:text-gray-100 break-all">
+                <TimeDisplay value={domain.verifiedAt} />
+              </p>
+            </div>
           )}
         </div>
       </div>

--- a/src/pages/routes/domains.tsx
+++ b/src/pages/routes/domains.tsx
@@ -2,6 +2,7 @@ import { BaseLayout } from "../layouts/base.tsx";
 import { VerificationBadge } from "../components/status-badge.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Domain } from "../../modules/domains/types/domain.types.ts";
 
 /**
@@ -95,7 +96,7 @@ export function DomainsPage({ domains, flash }: DomainsPageProps) {
                     <VerificationBadge verified={domain.dmarcVerified} label="DMARC" />
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {domain.createdAt.toLocaleDateString()}
+                    <TimeDisplay value={domain.createdAt} />
                   </td>
                   <td class="px-4 py-3">
                     <form method="POST" action={`/dashboard/domains/${domain.id}/delete`}>

--- a/src/pages/routes/email-detail.tsx
+++ b/src/pages/routes/email-detail.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { StatusBadge } from "../components/status-badge.tsx";
 import { HtmlPreview, HtmlPreviewScript } from "../components/html-preview.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import { BackArrowIcon } from "../assets/icons.tsx";
 import type { Email } from "../../modules/emails/types/email.types.ts";
 
@@ -103,9 +104,23 @@ export function EmailDetailPage({ email, isTrashed }: EmailDetailPageProps) {
           <DetailField label="Attempts" value={String(email.attempts)} />
           {email.lastError && <DetailField label="Last Error" value={email.lastError} />}
           {email.messageId && <DetailField label="Message ID" value={email.messageId} />}
-          <DetailField label="Created" value={email.createdAt.toISOString()} />
+          <div>
+            <p class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide mb-0.5">
+              Created
+            </p>
+            <p class="text-gray-900 dark:text-gray-100 break-all">
+              <TimeDisplay value={email.createdAt} />
+            </p>
+          </div>
           {email.sentAt && (
-            <DetailField label="Sent At" value={email.sentAt.toISOString()} />
+            <div>
+              <p class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide mb-0.5">
+                Sent At
+              </p>
+              <p class="text-gray-900 dark:text-gray-100 break-all">
+                <TimeDisplay value={email.sentAt} />
+              </p>
+            </div>
           )}
         </div>
       </div>

--- a/src/pages/routes/email-tombstones.tsx
+++ b/src/pages/routes/email-tombstones.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { EmailTombstone } from "../../modules/emails/models/email-tombstone.schema.ts";
 
 interface EmailTombstonesPageProps {
@@ -126,14 +127,10 @@ export function EmailTombstonesPage({
                     <StatusBadge status={t.status} />
                   </td>
                   <td class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {t.sentAt ? (
-                      t.sentAt.toISOString().slice(0, 10)
-                    ) : (
-                      <span class="text-gray-400">—</span>
-                    )}
+                    <TimeDisplay value={t.sentAt} />
                   </td>
                   <td class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {t.purgedAt.toISOString().slice(0, 10)}
+                    <TimeDisplay value={t.purgedAt} />
                   </td>
                 </tr>
               ))}

--- a/src/pages/routes/emails-trash.tsx
+++ b/src/pages/routes/emails-trash.tsx
@@ -3,6 +3,7 @@ import { StatusBadge } from "../components/status-badge.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import { BackArrowIcon } from "../assets/icons.tsx";
 import type { Email } from "../../modules/emails/types/email.types.ts";
 
@@ -164,7 +165,7 @@ export function EmailsTrashPage({
                         {email.subject}
                       </td>
                       <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {email.deletedAt?.toLocaleDateString() ?? "—"}
+                        <TimeDisplay value={email.deletedAt} />
                       </td>
                     </tr>
                   ))}

--- a/src/pages/routes/emails.tsx
+++ b/src/pages/routes/emails.tsx
@@ -3,6 +3,7 @@ import { StatusBadge } from "../components/status-badge.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Email } from "../../modules/emails/types/email.types.ts";
 
 /**
@@ -169,17 +170,8 @@ export function EmailsPage({
                       >
                         {email.subject}
                       </td>
-                      <td
-                        class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap"
-                        title={email.createdAt.toISOString()}
-                      >
-                        {email.createdAt.toLocaleString(undefined, {
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit",
-                        })}
+                      <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        <TimeDisplay value={email.createdAt} />
                       </td>
                       <td class="px-4 py-3 text-right">
                         {/* Per-row trash submits its own one-id form */}

--- a/src/pages/routes/inbound-detail.tsx
+++ b/src/pages/routes/inbound-detail.tsx
@@ -1,5 +1,6 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { HtmlPreview, HtmlPreviewScript } from "../components/html-preview.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import { BackArrowIcon } from "../assets/icons.tsx";
 import type { InboundEmail } from "../../modules/inbound/types/inbound.types.ts";
 
@@ -106,7 +107,14 @@ export function InboundDetailPage({ email, isTrashed }: InboundDetailPageProps) 
           <DetailField label="From" value={email.fromAddress} />
           <DetailField label="To" value={email.toAddress} />
           <DetailField label="Subject" value={email.subject ?? "(No subject)"} />
-          <DetailField label="Received At" value={email.receivedAt.toISOString()} />
+          <div>
+            <p class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide mb-0.5">
+              Received At
+            </p>
+            <p class="text-gray-900 dark:text-gray-100 break-all">
+              <TimeDisplay value={email.receivedAt} />
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/pages/routes/inbound-trash.tsx
+++ b/src/pages/routes/inbound-trash.tsx
@@ -2,6 +2,7 @@ import { BaseLayout } from "../layouts/base.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import { BackArrowIcon } from "../assets/icons.tsx";
 import type { InboundEmail } from "../../modules/inbound/types/inbound.types.ts";
 
@@ -152,7 +153,7 @@ export function InboundTrashPage({
                         {email.subject}
                       </td>
                       <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {email.deletedAt?.toLocaleDateString() ?? "—"}
+                        <TimeDisplay value={email.deletedAt} />
                       </td>
                     </tr>
                   ))}

--- a/src/pages/routes/inbound.tsx
+++ b/src/pages/routes/inbound.tsx
@@ -2,6 +2,7 @@ import { BaseLayout } from "../layouts/base.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { InboundEmail } from "../../modules/inbound/types/inbound.types.ts";
 
 /**
@@ -120,7 +121,7 @@ export function InboundPage({ emails, total, page, limit, flash }: InboundPagePr
                         {email.subject}
                       </td>
                       <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {email.receivedAt.toLocaleDateString()}
+                        <TimeDisplay value={email.receivedAt} />
                       </td>
                       <td class="px-4 py-3 text-right">
                         <button

--- a/src/pages/routes/suppressions.tsx
+++ b/src/pages/routes/suppressions.tsx
@@ -2,6 +2,7 @@ import { BaseLayout } from "../layouts/base.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
 import { Pagination } from "../components/pagination.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Suppression } from "../../modules/suppressions/types/suppression.types.ts";
 import type { ApiKey } from "../../modules/api-keys/types/api-key.types.ts";
 
@@ -204,10 +205,10 @@ export function SuppressionsPage({
                         )}
                       </td>
                       <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap text-xs">
-                        {sup.expiresAt ? sup.expiresAt.toLocaleString() : "Permanent"}
+                        <TimeDisplay value={sup.expiresAt} fallback="Permanent" />
                       </td>
                       <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap text-xs">
-                        {sup.createdAt.toLocaleString()}
+                        <TimeDisplay value={sup.createdAt} />
                       </td>
                       <td class="px-4 py-3 text-right">
                         <form

--- a/src/pages/routes/templates.tsx
+++ b/src/pages/routes/templates.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Template } from "../../modules/templates/types/template.types.ts";
 
 interface TemplatesPageProps {
@@ -155,7 +156,7 @@ export function TemplatesPage({ templates, flash }: TemplatesPageProps) {
                       : "—"}
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {template.createdAt.toLocaleDateString()}
+                    <TimeDisplay value={template.createdAt} />
                   </td>
                   <td class="px-4 py-3">
                     <form

--- a/src/pages/routes/webhook-deliveries.tsx
+++ b/src/pages/routes/webhook-deliveries.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Webhook } from "../../modules/webhooks/types/webhook.types.ts";
 import type { WebhookDelivery } from "../../modules/webhooks/models/webhook-delivery.schema.ts";
 
@@ -130,7 +131,7 @@ export function WebhookDeliveriesPage({
                     )}
                   </td>
                   <td class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {d.createdAt.toISOString().slice(0, 19).replace("T", " ")}
+                    <TimeDisplay value={d.createdAt} />
                   </td>
                 </tr>
               ))}

--- a/src/pages/routes/webhook-delivery-detail.tsx
+++ b/src/pages/routes/webhook-delivery-detail.tsx
@@ -1,5 +1,6 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { WebhookDelivery } from "../../modules/webhooks/models/webhook-delivery.schema.ts";
 import type { Webhook } from "../../modules/webhooks/types/webhook.types.ts";
 
@@ -66,16 +67,20 @@ export function WebhookDeliveryDetailPage({
           }
           mono
         />
-        <SummaryCard
-          label={delivery.deliveredAt ? "Delivered at" : "Next attempt"}
-          value={
-            delivery.deliveredAt
-              ? delivery.deliveredAt.toISOString().slice(0, 19).replace("T", " ")
-              : delivery.status === "pending"
-                ? delivery.nextAttemptAt.toISOString().slice(0, 19).replace("T", " ")
-                : "—"
-          }
-        />
+        <div class="border border-gray-200 dark:border-gray-800 rounded-lg p-4">
+          <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            {delivery.deliveredAt ? "Delivered at" : "Next attempt"}
+          </div>
+          <div class="text-lg font-semibold mt-1">
+            {delivery.deliveredAt ? (
+              <TimeDisplay value={delivery.deliveredAt} />
+            ) : delivery.status === "pending" ? (
+              <TimeDisplay value={delivery.nextAttemptAt} />
+            ) : (
+              "—"
+            )}
+          </div>
+        </div>
       </div>
 
       {/* Replay action — only meaningful for non-delivered rows */}

--- a/src/pages/routes/webhooks.tsx
+++ b/src/pages/routes/webhooks.tsx
@@ -1,6 +1,7 @@
 import { BaseLayout } from "../layouts/base.tsx";
 import { FlashMessage } from "../components/flash-message.tsx";
 import { EmptyState } from "../components/empty-state.tsx";
+import { TimeDisplay } from "../components/time-display.tsx";
 import type { Webhook } from "../../modules/webhooks/types/webhook.types.ts";
 
 /**
@@ -132,7 +133,7 @@ export function WebhooksPage({ webhooks, flash, secret }: WebhooksPageProps) {
                     </div>
                   </td>
                   <td class="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {webhook.createdAt.toLocaleDateString()}
+                    <TimeDisplay value={webhook.createdAt} />
                   </td>
                   <td class="px-4 py-3">
                     <div class="flex items-center gap-3">


### PR DESCRIPTION
Closes #104.

## Summary

- New shared `<TimeDisplay>` component renders timestamps in the **viewer's** browser locale + timezone, not the server's (which is UTC in Docker).
- Display reads as relative time: `5m ago`, `Yesterday 14:32`, `Jan 5, 14:32`, `Jan 5, 2024, 14:32`. Hover always reveals the full absolute timestamp with timezone.
- **No date-only output anywhere.** Every rendered value carries date and time together — addressed multiple pieces of feedback that the dashboard was unreadable when only a date was shown.

## How it works

Server emits a semantic `<time datetime="<iso>" data-bm-time>` tag with a static UTC fallback. One hydration script in `BaseLayout` walks every such element on load and rewrites:

- `textContent` → relative time via `Intl.DateTimeFormat` in the browser's locale + timezone.
- `title` → full absolute timestamp with timezone (`May 29, 2026, 02:00:34 PM GMT+2`).

The script also exposes `window.bmHydrateTimes()` so future dynamic injection can re-run hydration if ever needed.

## Why client-side

Server-side `toLocaleString()` runs in the Bun process's TZ — UTC in Docker, every viewer sees UTC regardless of where they are. Reading TZ from a cookie would require a JS round-trip on first visit and still wouldn't help across devices. The dashboard already hard-requires JS (dark mode, chip input, HTML preview iframes), so a small hydration script costs nothing extra.

## Scope of the sweep

20 files touched, ~25 call sites migrated:

- `api-keys.tsx`, `domains.tsx`, `domain-detail.tsx`, `emails.tsx`, `email-detail.tsx`, `emails-trash.tsx`
- `inbound.tsx`, `inbound-detail.tsx`, `inbound-trash.tsx`
- `suppressions.tsx`, `templates.tsx`, `webhooks.tsx`, `webhook-deliveries.tsx`, `webhook-delivery-detail.tsx`
- `email-tombstones.tsx`, `dmarc-reports.tsx`, `dmarc-report-detail.tsx`

Every former `toLocaleString()` / `toLocaleDateString()` / `toISOString()` call in the dashboard is gone. New component + script live in [src/pages/components/time-display.tsx](src/pages/components/time-display.tsx).

## Docs

- `CHANGELOG.md` — `[Unreleased]` entry.
- `docs/dashboard.md` — new "Timestamps" section with usage rules and a "don't call `toLocaleString` in JSX" guidance line.

## Trade-off

Brief flash of UTC fallback text before JS runs on initial paint. The fallback is `YYYY-MM-DD HH:mm UTC` — unambiguous and timezone-explicit so a no-JS viewer never confuses it for local time.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun test test/unit test/e2e` — 355 pass.
- [x] `bun run test:integration` — 95 pass.
- [ ] Manual: load `/dashboard/emails`, confirm timestamps read in local time + relative phrasing; hover shows full absolute timestamp with TZ.
- [ ] Manual: load `/dashboard/api-keys`, confirm `lastUsedAt = null` shows "Never".
- [ ] Manual: switch system TZ, reload, confirm formatting updates accordingly.