### PR TITLE
feat(inbound): per-domain inbound notification email on receive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ POSTGRES_DB=bunmail
 PORT=3000
 HOST=0.0.0.0
 
+# Public base URL of this instance (e.g. https://mail.example.com), no
+# trailing slash. Used to build absolute links in outbound system mail —
+# currently the "view in dashboard" link in inbound notifications. Leave
+# empty to omit those links.
+# APP_BASE_URL=https://mail.example.com
+
 # ── Email Delivery ──
 # Hostname used in the SMTP HELO command and Message-ID header.
 # Should match your server's PTR (reverse DNS) record for best deliverability.
@@ -74,6 +80,21 @@ SMTP_RATE_LIMIT_ENABLED=true
 SMTP_RATE_LIMIT_MAX=10
 # Rate limit window in seconds
 SMTP_RATE_LIMIT_WINDOW=60
+
+# ── Inbound Notifications (#106) ──
+# When an inbound message is received for a domain that has a notify
+# address set (per-domain, from the dashboard or the domains API), BunMail
+# sends a "you have new mail" summary email to that address, signed with
+# the recipient domain's own DKIM key. Point each domain's notify address
+# at an EXTERNAL mailbox — an address on a domain BunMail itself receives
+# for would loop (and is skipped by the sender-domain loop guard).
+#
+# Master kill switch. When false, no inbound notifications are sent
+# regardless of any domain's notify address. Default: true
+INBOUND_NOTIFY_ENABLED=true
+# Local-part of the notification From address. The full From is
+# <local>@<recipient domain>. Default: notifications
+INBOUND_NOTIFY_FROM_LOCAL=notifications
 
 # ── Dashboard ──
 # Password for the /dashboard web UI. Leave empty to disable the dashboard.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -452,6 +452,7 @@ Both `emails` and `inbound_emails` use a `deleted_at` soft-delete marker. Settin
 | dkim_selector     | varchar(63)    | NOT NULL, default `'bunmail'`|
 | unsubscribe_email | varchar(255)   | nullable; per-domain mailto override for `List-Unsubscribe` (#40) |
 | unsubscribe_url   | text           | nullable; per-domain URL form for `List-Unsubscribe` + One-Click POST (#40) |
+| notify_email      | varchar(255)   | nullable; address notified on inbound mail for this domain (#106) |
 | spf_verified      | boolean        | NOT NULL, default `false`    |
 | dkim_verified     | boolean        | NOT NULL, default `false`    |
 | dmarc_verified    | boolean        | NOT NULL, default `false`    |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Inbound email notifications (#106).** Each domain can carry a `notify_email`. When the inbound SMTP receiver accepts a message for a recipient on that domain, BunMail sends a "you have new mail" summary email (sender, subject, ~200-char preview, and a dashboard link when `APP_BASE_URL` is set) to that address — sent from `<INBOUND_NOTIFY_FROM_LOCAL>@<recipient domain>` (default `notifications@…`) and DKIM-signed with the domain's own key, so it passes the same SPF/DKIM as outbound. Set or clear the address from the domain detail page in the dashboard, or via the new optional `notifyEmail` field on `POST /api/v1/domains`. Sent fire-and-forget after the inbound row is stored (never delays the SMTP ack); bounces (DSNs) and DMARC reports never trigger it; a sender-domain loop guard skips notifications for mail from one of your own registered domains. New env: `INBOUND_NOTIFY_ENABLED` (default true, global kill switch), `INBOUND_NOTIFY_FROM_LOCAL` (default `notifications`), and `APP_BASE_URL` (optional, for the dashboard link). Webhook events are unchanged — inbound arrival continues to fire the existing `email.received` event.
+
+### Changed
+
+- **Schema:** adds `domains.notify_email varchar(255) NULL` (#106). Legacy rows default to null (notifications disabled). Run `bun run db:migrate` (or rebuild via `docker compose up -d --build`) before deploying.
+
 ## [0.6.1] - 2026-05-29
 
 > **Theme: dashboard timestamps in viewer machine time.** Every server-rendered timestamp on the dashboard now formats in the viewer's browser locale + timezone instead of the server's (UTC in Docker), with relative phrasing for recent activity. No schema changes, no API changes — pull, restart, reload.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Run [mail-tester.com](https://www.mail-tester.com) to get a deliverability score
 - **Templates** — Mustache-style `{{variable}}` substitution
 - **Webhooks** — HMAC-signed events with timestamp-bound replay protection: `email.sent`, `email.failed`, `email.bounced`, `email.received`, `email.complained`
 - **Inbound SMTP** — receive and store incoming mail with DNSBL, recipient validation, and per-IP rate limiting
+- **Inbound notifications** — per-domain "you have new mail" summary email on receive, DKIM-signed from the recipient domain; opt-in via each domain's `notify_email`
 - **API key auth** — SHA-256 hashed Bearer tokens with sliding-window rate limiting
 - **Trash + auto-purge** — Gmail-style soft delete on outbound and inbound, restorable until purged after `TRASH_RETENTION_DAYS` (default 7)
 - **Suppression list** — per-API-key list of addresses we refuse to send to; gate runs at `POST /emails/send` so bounced/unsubscribed recipients can't re-tank IP reputation

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,7 @@ Register a new sender domain. Automatically generates a 2048-bit RSA keypair for
 | `name`              | string | Yes      | Domain name (e.g. "example.com")                                                                 |
 | `unsubscribeEmail`  | string | No       | Mailbox emitted in `List-Unsubscribe: <mailto:...>`. Defaults to `unsubscribe@<name>` if omitted. |
 | `unsubscribeUrl`    | string | No       | RFC 8058 one-click HTTPS endpoint. When set, mail also carries `List-Unsubscribe-Post: List-Unsubscribe=One-Click`. |
+| `notifyEmail`       | string | No       | Address notified when inbound mail is received for this domain (#106). Use an external mailbox. Editable later from the dashboard; empty clears it. |
 
 **Response:**
 

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -33,6 +33,7 @@ Table: `domains`
 | dkim_selector     | varchar(63)    | NOT NULL, default `'bunmail'`|
 | unsubscribe_email | varchar(255)   | nullable — overrides the default `unsubscribe@<from-domain>` mailto in the `List-Unsubscribe` header (#40) |
 | unsubscribe_url   | text           | nullable — adds an `https` URL form to `List-Unsubscribe` and enables `List-Unsubscribe-Post: List-Unsubscribe=One-Click` (#40) |
+| notify_email      | varchar(255)   | nullable — when set, inbound mail received for this domain triggers a summary notification email to this address (#106). Use an external mailbox. |
 | spf_verified      | boolean        | NOT NULL, default `false`    |
 | dkim_verified     | boolean        | NOT NULL, default `false`    |
 | dmarc_verified    | boolean        | NOT NULL, default `false`    |
@@ -77,6 +78,12 @@ Returns all registered domains.
 #### `getDomainById(id): Promise<Domain | undefined>`
 Returns a single domain by ID.
 
+#### `getDomainByName(name): Promise<Domain | undefined>`
+Returns a single domain by its name. Used by the inbound-notification path (#106) to resolve the recipient domain's `notify_email` + DKIM material.
+
+#### `updateDomainNotifyEmail(id, notifyEmail): Promise<Domain | undefined>`
+Sets (or clears, when passed `null`) the inbound-notification address for a domain (#106). Returns `undefined` when no row matches the id.
+
 #### `deleteDomain(id): Promise<Domain | undefined>`
 Hard-deletes a domain and its keys.
 
@@ -102,3 +109,27 @@ All routes require Bearer token auth and are rate-limited.
 | GET    | /api/v1/domains/:id           | Get domain details       |
 | POST   | /api/v1/domains/:id/verify    | Verify DNS records       |
 | DELETE | /api/v1/domains/:id           | Delete domain            |
+
+`POST /api/v1/domains` accepts an optional `notifyEmail` field to set the
+inbound-notification address at create time (see below).
+
+## Inbound Notifications (#106)
+
+Each domain can carry a `notify_email`. When BunMail's inbound SMTP receiver
+accepts a message for a recipient on that domain, it sends a short "you have
+new mail" summary email (sender, subject, preview, and — when `APP_BASE_URL`
+is configured — a dashboard link) to the notify address. The notification is
+sent **from** `<INBOUND_NOTIFY_FROM_LOCAL>@<domain>` (default
+`notifications@<domain>`) and DKIM-signed with the domain's own key, so it
+passes the same SPF/DKIM you already set up for outbound.
+
+- **Set it** from the dashboard (the domain detail page) via
+  `POST /dashboard/domains/:id/notify-email`, or at create time with the
+  `notifyEmail` field on `POST /api/v1/domains`. An empty submission clears it.
+- **Point it at an external mailbox.** A notify address on a domain BunMail
+  itself receives for would loop; such loops (and any mail whose sender domain
+  is a registered BunMail domain) are skipped by the sender-domain loop guard.
+- **Disable globally** with `INBOUND_NOTIFY_ENABLED=false` (operator kill
+  switch); per-domain, just leave `notify_email` empty.
+- Bounces (DSNs) and DMARC aggregate reports never trigger a notification —
+  they are routed away before the inbound store.

--- a/docs/inbound.md
+++ b/docs/inbound.md
@@ -129,6 +129,40 @@ All three layers fail open on errors (DNS timeout, DB unreachable). This means l
 3. DATA command → message parsed with `mailparser`
 4. Sender, recipient, subject, HTML, text, and raw message stored in `inbound_emails`
 5. `email.received` webhook event fired to all subscribed webhooks
+6. If the recipient domain has a `notify_email` set, a summary notification email is sent (fire-and-forget) — see below
+
+Bounces (DSNs) and DMARC aggregate reports are detected earlier and routed to their own handlers; they are **not** stored in `inbound_emails` and never fire steps 5–6.
+
+## Inbound Notifications (#106)
+
+A domain can opt in to email notifications by setting its `notify_email`
+(per domain — from the dashboard's domain detail page, or the `notifyEmail`
+field on `POST /api/v1/domains`). When mail is received for that domain,
+BunMail sends a short "you have new mail" summary (sender, subject, a ~200-char
+preview, and a dashboard link when `APP_BASE_URL` is set) to the notify address.
+
+- The notification is sent **from** `<INBOUND_NOTIFY_FROM_LOCAL>@<recipient
+  domain>` (default `notifications@<domain>`) and DKIM-signed with that
+  domain's own key — same SPF/DKIM as outbound.
+- It is sent fire-and-forget after the inbound row is stored, so it never
+  delays the SMTP acknowledgement.
+- **Loop guard:** mail whose sender domain is itself a registered BunMail
+  domain is skipped (a notification that loops back in won't re-notify). Point
+  `notify_email` at an external mailbox.
+- **Kill switch:** `INBOUND_NOTIFY_ENABLED=false` disables all inbound
+  notifications regardless of per-domain settings.
+
+> **Limitations (v1).** The inbound path does **not** verify SPF/DKIM/DMARC
+> on received mail today, so a notification relays the (unauthenticated)
+> sender, subject, and body preview of whatever was accepted — treat the
+> notification's contents as untrusted, exactly like the inbox itself. The
+> HTML part is escaped (no script injection), and the From/Subject are set
+> via Nodemailer (no header injection). Notification volume is bounded only
+> by the SMTP per-IP connection rate limit — there is no per-`notify_email`
+> throttle/digest yet. Inbound sender authentication and a per-address rate
+> cap are tracked as follow-ups on #106.
+
+See [docs/domains.md](domains.md#inbound-notifications-106) for the field and endpoints.
 
 ## Service Methods
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -81,6 +81,11 @@ SMTP_ENABLED=true
 SMTP_PORT=25
 LOG_LEVEL=info
 TRASH_RETENTION_DAYS=7
+# Optional — public base URL, used for the dashboard link in inbound notifications
+APP_BASE_URL=https://mail.yourdomain.com
+# Optional — inbound notifications (per-domain notify_email is the opt-in)
+INBOUND_NOTIFY_ENABLED=true
+INBOUND_NOTIFY_FROM_LOCAL=notifications
 ```
 
 > Generate a session secret: `openssl rand -hex 32`
@@ -88,6 +93,10 @@ TRASH_RETENTION_DAYS=7
 > Generate a DKIM encryption key: `openssl rand -base64 32`. **Required** — boot fails with a clear error if missing or not 32 bytes after base64 decode. Encrypts every domain's DKIM private key at rest with AES-256-GCM (#23). See [SECURITY.md](../SECURITY.md#dkim-private-key-encryption-at-rest) for the format and rotation procedure.
 
 > `TRASH_RETENTION_DAYS` — how long soft-deleted emails (outbound and inbound) stay in trash before being permanently purged. Default `7`.
+
+> `APP_BASE_URL` — public base URL of this instance (no trailing slash). Used only to build the "view in dashboard" link in inbound notification emails; leave unset to omit the link.
+
+> `INBOUND_NOTIFY_ENABLED` / `INBOUND_NOTIFY_FROM_LOCAL` — inbound notifications (#106). When a domain has a `notify_email` set, received mail for it triggers a summary email from `<INBOUND_NOTIFY_FROM_LOCAL>@<domain>` (default `notifications`). `INBOUND_NOTIFY_ENABLED=false` is a global kill switch. See [docs/inbound.md](inbound.md#inbound-notifications-106).
 
 ## 2. DNS Records
 

--- a/drizzle/0008_new_darwin.sql
+++ b/drizzle/0008_new_darwin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "domains" ADD COLUMN "notify_email" varchar(255);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1330 @@
+{
+  "id": "2e1be4c2-de1b-42ac-9157-6599e55cbd0b",
+  "prevId": "9771b9ec-06a8-4ae0-952b-cbbbd6325a07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dmarc_records": {
+      "name": "dmarc_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dkim_aligned": {
+          "name": "dkim_aligned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spf_aligned": {
+          "name": "spf_aligned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_from": {
+          "name": "header_from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dkim_auth_domain": {
+          "name": "dkim_auth_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_result": {
+          "name": "dkim_result",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spf_auth_domain": {
+          "name": "spf_auth_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spf_result": {
+          "name": "spf_result",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dmarc_records_report_id_idx": {
+          "name": "dmarc_records_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dmarc_records_source_ip_idx": {
+          "name": "dmarc_records_source_ip_idx",
+          "columns": [
+            {
+              "expression": "source_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dmarc_records_report_id_dmarc_reports_id_fk": {
+          "name": "dmarc_records_report_id_dmarc_reports_id_fk",
+          "tableFrom": "dmarc_records",
+          "tableTo": "dmarc_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dmarc_reports": {
+      "name": "dmarc_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_name": {
+          "name": "org_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_email": {
+          "name": "org_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_p": {
+          "name": "policy_p",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_pct": {
+          "name": "policy_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "raw_xml": {
+          "name": "raw_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dmarc_reports_org_email_report_id_unique": {
+          "name": "dmarc_reports_org_email_report_id_unique",
+          "columns": [
+            {
+              "expression": "org_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dmarc_reports_domain_date_end_idx": {
+          "name": "dmarc_reports_domain_date_end_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dkim_private_key": {
+          "name": "dkim_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bunmail'"
+        },
+        "spf_verified": {
+          "name": "spf_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dkim_verified": {
+          "name": "dkim_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dmarc_verified": {
+          "name": "dmarc_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_email": {
+          "name": "unsubscribe_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_url": {
+          "name": "unsubscribe_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domains_name_unique": {
+          "name": "domains_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_tombstones": {
+      "name": "email_tombstones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_tombstones_message_id": {
+          "name": "idx_email_tombstones_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_tombstones_api_key_purged": {
+          "name": "idx_email_tombstones_api_key_purged",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_emails_status_created": {
+          "name": "idx_emails_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_emails_api_key_id": {
+          "name": "idx_emails_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_emails_api_key_deleted": {
+          "name": "idx_emails_api_key_deleted",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "emails_api_key_id_api_keys_id_fk": {
+          "name": "emails_api_key_id_api_keys_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "emails_domain_id_domains_id_fk": {
+          "name": "emails_domain_id_domains_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_emails": {
+      "name": "inbound_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbound_received_at": {
+          "name": "idx_inbound_received_at",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_deleted_at": {
+          "name": "idx_inbound_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppressions": {
+      "name": "suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_code": {
+          "name": "diagnostic_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "suppressions_api_key_email_unique": {
+          "name": "suppressions_api_key_email_unique",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suppressions_api_key_email_idx": {
+          "name": "suppressions_api_key_email_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppressions_api_key_id_api_keys_id_fk": {
+          "name": "suppressions_api_key_id_api_keys_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suppressions_source_email_id_emails_id_fk": {
+          "name": "suppressions_source_email_id_emails_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "source_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "templates_api_key_id_api_keys_id_fk": {
+          "name": "templates_api_key_id_api_keys_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_pending_idx": {
+          "name": "webhook_deliveries_due_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_per_webhook_idx": {
+          "name": "webhook_deliveries_per_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhooks_api_key_id_api_keys_id_fk": {
+          "name": "webhooks_api_key_id_api_keys_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779675195574,
       "tag": "0007_talented_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1780494343646,
+      "tag": "0008_new_darwin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,15 @@ export const config = {
     host: optionalEnv("HOST", "0.0.0.0"),
   },
 
+  /**
+   * Public base URL of this BunMail instance (e.g. "https://mail.example.com"),
+   * no trailing slash. Used to build absolute links in outbound system mail —
+   * currently the "view in dashboard" link in inbound notifications (#106).
+   * Optional: when empty, those emails simply omit the link. Trailing slash
+   * is stripped so callers can always append "/dashboard/...".
+   */
+  appBaseUrl: optionalEnv("APP_BASE_URL", "").replace(/\/+$/, ""),
+
   mail: {
     /** Hostname used in SMTP HELO command and Message-ID header */
     hostname: optionalEnv("MAIL_HOSTNAME", "localhost"),
@@ -150,6 +159,31 @@ export const config = {
       /** Rate limit window in seconds */
       rateLimitWindowSec: parseInt(optionalEnv("SMTP_RATE_LIMIT_WINDOW", "60"), 10),
     },
+  },
+
+  /**
+   * Inbound notification (#106). When an inbound message is accepted by
+   * the SMTP receiver for a domain that has a `notify_email` set, BunMail
+   * sends a "you have new mail" summary email to that address, signed with
+   * the recipient domain's own DKIM key. Per-domain opt-in (set the
+   * domain's notify email); these are the instance-wide knobs.
+   */
+  inboundNotify: {
+    /**
+     * Master switch. When false, no inbound notifications are sent
+     * regardless of any domain's `notify_email`. Default true (the
+     * per-domain `notify_email` being null is the real opt-in — this is
+     * an operator kill switch).
+     */
+    enabled: optionalEnv("INBOUND_NOTIFY_ENABLED", "true") === "true",
+
+    /**
+     * Local-part of the From address for notification emails. The full
+     * From is `<fromLocalPart>@<recipient domain>`, so notifications are
+     * sent from the same domain that received the mail and signed with
+     * that domain's DKIM key. Default "notifications".
+     */
+    fromLocalPart: optionalEnv("INBOUND_NOTIFY_FROM_LOCAL", "notifications"),
   },
 
   /** Password-protected web dashboard at /dashboard */

--- a/src/modules/domains/domains.plugin.ts
+++ b/src/modules/domains/domains.plugin.ts
@@ -39,7 +39,10 @@ export const domainsPlugin = new Elysia({
     async ({ body }) => {
       logger.info("POST /api/v1/domains", { name: body.name });
 
-      const domain = await domainService.createDomain({ name: body.name });
+      const domain = await domainService.createDomain({
+        name: body.name,
+        notifyEmail: body.notifyEmail,
+      });
 
       return {
         success: true,

--- a/src/modules/domains/dtos/create-domain.dto.ts
+++ b/src/modules/domains/dtos/create-domain.dto.ts
@@ -30,4 +30,11 @@ export const createDomainDto = t.Object({
    * Leave unset for transactional mail.
    */
   unsubscribeUrl: t.Optional(t.String({ format: "uri", minLength: 8, maxLength: 2048 })),
+
+  /**
+   * Address notified when inbound mail is received for this domain (#106).
+   * Optional at create-time; can also be set/cleared later from the
+   * dashboard. Point this at an external mailbox.
+   */
+  notifyEmail: t.Optional(t.String({ format: "email", minLength: 3, maxLength: 255 })),
 });

--- a/src/modules/domains/models/domain.schema.ts
+++ b/src/modules/domains/models/domain.schema.ts
@@ -53,6 +53,18 @@ export const domains = pgTable("domains", {
    */
   unsubscribeUrl: text("unsubscribe_url"),
 
+  /**
+   * Address notified when inbound mail is received for this domain (#106).
+   * When set, every message accepted by the SMTP receiver for a recipient
+   * on this domain triggers a "you have new mail" summary email, sent from
+   * `<INBOUND_NOTIFY_FROM_LOCAL>@<name>` and DKIM-signed with this domain's
+   * own key. Null disables inbound notifications for the domain (the
+   * default). Point this at an EXTERNAL mailbox — an address on a domain
+   * BunMail itself receives for would loop (and is skipped by the
+   * sender-domain loop guard).
+   */
+  notifyEmail: varchar("notify_email", { length: 255 }),
+
   /** When this domain was added */
   createdAt: timestamp("created_at").notNull().defaultNow(),
 

--- a/src/modules/domains/serializations/domain.serialization.ts
+++ b/src/modules/domains/serializations/domain.serialization.ts
@@ -19,6 +19,8 @@ export interface SerializedDomain {
   unsubscribeEmail: string | null;
   /** One-click HTTPS unsubscribe endpoint; null disables `List-Unsubscribe-Post`. */
   unsubscribeUrl: string | null;
+  /** Address notified on inbound mail for this domain; null disables notifications. */
+  notifyEmail: string | null;
   createdAt: Date;
 }
 
@@ -39,6 +41,7 @@ export function serializeDomain(domain: Domain): SerializedDomain {
     verifiedAt: domain.verifiedAt,
     unsubscribeEmail: domain.unsubscribeEmail,
     unsubscribeUrl: domain.unsubscribeUrl,
+    notifyEmail: domain.notifyEmail,
     createdAt: domain.createdAt,
   };
 }

--- a/src/modules/domains/services/domain.service.ts
+++ b/src/modules/domains/services/domain.service.ts
@@ -75,6 +75,7 @@ export async function createDomain(input: CreateDomainInput): Promise<Domain> {
       dkimSelector: "bunmail",
       unsubscribeEmail: input.unsubscribeEmail ?? null,
       unsubscribeUrl: input.unsubscribeUrl ?? null,
+      notifyEmail: input.notifyEmail ?? null,
     })
     .returning();
 
@@ -127,6 +128,30 @@ export async function getDomainById(id: string): Promise<Domain | undefined> {
 }
 
 /**
+ * Retrieves a single domain by its name.
+ *
+ * Used by the inbound-notification path (#106) to resolve the recipient
+ * domain's `notify_email` + DKIM material from the address an inbound
+ * message was sent to. Returns the full row (including the encrypted
+ * `dkimPrivateKey`) so the caller can sign the notification with the
+ * domain's own key.
+ *
+ * @param name - The domain name (e.g. "example.com")
+ * @returns The domain row, or undefined if not found
+ */
+export async function getDomainByName(name: string): Promise<Domain | undefined> {
+  logger.debug("Fetching domain by name", { name });
+
+  const [domain] = await db.select().from(domains).where(eq(domains.name, name)).limit(1);
+
+  if (!domain) {
+    logger.debug("Domain not found by name", { name });
+  }
+
+  return domain;
+}
+
+/**
  * Checks whether a domain name is registered in BunMail.
  * Used by inbound SMTP spam protection to reject mail to unknown domains.
  *
@@ -140,6 +165,43 @@ export async function domainExistsByName(name: string): Promise<boolean> {
     .where(eq(domains.name, name))
     .limit(1);
   return !!domain;
+}
+
+/**
+ * Updates the inbound-notification address for a domain (#106).
+ *
+ * Pass a non-empty address to enable inbound notifications for the
+ * domain, or `null` to disable them. Returns the updated row, or
+ * `undefined` when no domain matches the id.
+ *
+ * `updatedAt` is bumped so the change is reflected in the audit
+ * timestamp, mirroring how other domain mutations behave.
+ *
+ * @param id - The domain ID to update
+ * @param notifyEmail - The address to notify, or null to clear
+ * @returns The updated domain row, or undefined if not found
+ */
+export async function updateDomainNotifyEmail(
+  id: string,
+  notifyEmail: string | null,
+): Promise<Domain | undefined> {
+  logger.info("Updating domain notify email", {
+    id,
+    hasNotifyEmail: notifyEmail !== null,
+  });
+
+  const [domain] = await db
+    .update(domains)
+    .set({ notifyEmail, updatedAt: new Date() })
+    .where(eq(domains.id, id))
+    .returning();
+
+  if (!domain) {
+    logger.warn("Domain not found for notify-email update", { id });
+    return undefined;
+  }
+
+  return domain;
 }
 
 /**

--- a/src/modules/domains/types/domain.types.ts
+++ b/src/modules/domains/types/domain.types.ts
@@ -21,4 +21,6 @@ export interface CreateDomainInput {
   unsubscribeEmail?: string;
   /** RFC 8058 one-click HTTPS unsubscribe endpoint. Optional. */
   unsubscribeUrl?: string;
+  /** Address notified when inbound mail arrives for this domain (#106). Optional. */
+  notifyEmail?: string;
 }

--- a/src/modules/inbound/services/inbound-notify.service.ts
+++ b/src/modules/inbound/services/inbound-notify.service.ts
@@ -1,0 +1,321 @@
+import { randomBytes } from "crypto";
+import { config } from "../../../config.ts";
+import { logger } from "../../../utils/logger.ts";
+import { redactEmail } from "../../../utils/redact.ts";
+import { decryptSecret, isEncryptedSecret } from "../../../utils/crypto.ts";
+import { sendMail } from "../../emails/services/mailer.service.ts";
+import type { DkimOptions } from "../../emails/services/mailer.service.ts";
+import {
+  getDomainByName,
+  domainExistsByName,
+} from "../../domains/services/domain.service.ts";
+import type { Domain } from "../../domains/types/domain.types.ts";
+
+/**
+ * Inbound notification service (#106).
+ *
+ * When the SMTP receiver accepts an inbound message for a domain that has
+ * a `notify_email` set, this sends a small "you have new mail" summary
+ * email to that address — sender, subject, a short preview, and (when
+ * `APP_BASE_URL` is configured) a link to the message in the dashboard.
+ *
+ * The notification is sent FROM `<INBOUND_NOTIFY_FROM_LOCAL>@<recipient
+ * domain>` and DKIM-signed with that domain's own key, so it passes the
+ * same SPF/DKIM the operator already set up for outbound. It is sent
+ * out-of-band via {@link sendMail} (no `emails` row) — there is no owning
+ * API key in the per-domain model, and a notification doesn't belong in
+ * the sender's outbound log. The send outcome is logged instead.
+ *
+ * The receiver calls {@link notifyInboundReceived} fire-and-forget after
+ * the inbound row is persisted, so a slow notification never delays the
+ * SMTP acknowledgement.
+ */
+
+/** How many characters of the inbound body to include as a preview. */
+const NOTIFY_PREVIEW_CHARS = 200;
+
+/** The composed notification email, ready to hand to {@link sendMail}. */
+export interface InboundNotificationContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/** Inputs for {@link buildInboundNotification} — pure, no I/O. */
+export interface BuildNotificationInput {
+  /** Address the inbound mail was sent to (the BunMail mailbox). */
+  to: string;
+  /** Sender of the inbound mail. */
+  from: string;
+  /** Subject of the inbound mail, or null when absent. */
+  subject: string | null;
+  /** Plain-text body of the inbound mail, used for the preview. */
+  text: string | null;
+  /** Absolute dashboard URL for the message, or null to omit the link. */
+  detailUrl: string | null;
+}
+
+/** Escapes the five HTML-significant characters for safe interpolation. */
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" })[c] ?? c,
+  );
+}
+
+/**
+ * Collapses whitespace and truncates the inbound body to a short preview.
+ * Returns an empty string when there's no text part (e.g. HTML-only mail).
+ */
+function buildPreview(text: string | null): string {
+  if (!text) return "";
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= NOTIFY_PREVIEW_CHARS) return collapsed;
+  return collapsed.slice(0, NOTIFY_PREVIEW_CHARS).trimEnd() + "…";
+}
+
+/**
+ * Composes the summary notification email. Pure function — all values are
+ * provided by the caller, every user-controlled field is HTML-escaped in
+ * the HTML part, and the subject carries the original subject so the
+ * notification is glanceable in an inbox list.
+ */
+export function buildInboundNotification(
+  input: BuildNotificationInput,
+): InboundNotificationContent {
+  const originalSubject = input.subject?.trim() || "(no subject)";
+  const preview = buildPreview(input.text);
+
+  const subject = `New email at ${input.to}: ${originalSubject}`;
+
+  /** Plain-text part. */
+  const textLines = [
+    `You have a new email at ${input.to}.`,
+    "",
+    `From:    ${input.from}`,
+    `Subject: ${originalSubject}`,
+  ];
+  if (preview) {
+    textLines.push("", preview);
+  }
+  if (input.detailUrl) {
+    textLines.push("", `View it in your dashboard: ${input.detailUrl}`);
+  }
+  textLines.push(
+    "",
+    "—",
+    `Sent by BunMail because inbound notifications are enabled for ${input.to.split("@")[1] ?? input.to}.`,
+  );
+  const text = textLines.join("\n");
+
+  /** HTML part — escaped user input, minimal inline styling. */
+  const previewHtml = preview
+    ? `<p style="margin:16px 0;padding:12px 16px;background:#f6f8fa;border-radius:6px;color:#444;white-space:pre-wrap;">${escapeHtml(
+        preview,
+      )}</p>`
+    : "";
+  const linkHtml = input.detailUrl
+    ? `<p style="margin:16px 0;"><a href="${escapeHtml(
+        input.detailUrl,
+      )}" style="color:#0969da;">View it in your dashboard →</a></p>`
+    : "";
+  const html = [
+    `<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;font-size:15px;color:#1f2328;line-height:1.5;">`,
+    `<p style="margin:0 0 16px;">You have a new email at <strong>${escapeHtml(input.to)}</strong>.</p>`,
+    `<table style="border-collapse:collapse;font-size:14px;">`,
+    `<tr><td style="padding:2px 12px 2px 0;color:#656d76;">From</td><td>${escapeHtml(input.from)}</td></tr>`,
+    `<tr><td style="padding:2px 12px 2px 0;color:#656d76;">Subject</td><td>${escapeHtml(originalSubject)}</td></tr>`,
+    `</table>`,
+    previewHtml,
+    linkHtml,
+    `<hr style="border:none;border-top:1px solid #e1e4e8;margin:24px 0 12px;">`,
+    `<p style="margin:0;font-size:12px;color:#8b949e;">Sent by BunMail because inbound notifications are enabled for ${escapeHtml(
+      input.to.split("@")[1] ?? input.to,
+    )}.</p>`,
+    `</div>`,
+  ].join("");
+
+  return { subject, html, text };
+}
+
+/**
+ * Decrypts a domain's stored DKIM private key, mirroring the queue's
+ * fail-open behaviour: null stays null, plaintext (boot encrypter not yet
+ * run) is used as-is with a warning, and a decrypt failure logs and
+ * returns null so the notification still sends — unsigned — rather than
+ * being dropped.
+ */
+function decryptDkimPrivateKey(stored: string | null, domainName: string): string | null {
+  if (stored === null) return null;
+  if (!isEncryptedSecret(stored)) {
+    logger.warn("DKIM private key stored as plaintext — boot encrypter has not run", {
+      domain: domainName,
+    });
+    return stored;
+  }
+  try {
+    return decryptSecret(stored, config.dkimEncryptionKey);
+  } catch (err) {
+    logger.error("Failed to decrypt DKIM private key — sending notification unsigned", {
+      domain: domainName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/** Builds DKIM options from a domain row, or undefined when no key. */
+function resolveDkim(domain: Domain): DkimOptions | undefined {
+  const privateKey = decryptDkimPrivateKey(domain.dkimPrivateKey, domain.name);
+  if (!privateKey) return undefined;
+  return {
+    domainName: domain.name,
+    keySelector: domain.dkimSelector,
+    privateKey,
+  };
+}
+
+/** Inputs for {@link notifyInboundReceived}. */
+export interface NotifyInboundInput {
+  /** The `inb_…` id of the stored inbound row (for the dashboard link). */
+  inboundId: string;
+  /** Sender of the inbound mail. */
+  from: string;
+  /**
+   * The **envelope** RCPT TO addresses the receiver actually accepted
+   * (`session.envelope.rcptTo`). Domain resolution keys off these — NOT
+   * the spoofable `To:` header — so BCC / list mail still notifies the
+   * domain the message was received for, and a forged header can't steer
+   * which domain's identity/key signs the notification. One message can be
+   * addressed to several registered domains; each notify-enabled one gets
+   * its own notification.
+   */
+  recipients: string[];
+  /** Subject of the inbound mail, or null. */
+  subject: string | null;
+  /** Plain-text body of the inbound mail, or null. */
+  text: string | null;
+}
+
+/**
+ * Sends inbound notifications for every accepted recipient domain that has
+ * a `notify_email` configured.
+ *
+ * Resolution + guards:
+ *   1. **Loop guard** — skip entirely when the inbound sender's domain is
+ *      itself a registered BunMail domain. Notifications are sent from
+ *      `notifications@<our domain>`, so a notification that loops back in
+ *      (or any intra-system mail) is suppressed rather than re-notifying.
+ *   2. Group the accepted envelope recipients by domain; for each distinct
+ *      domain with a `notify_email`, send one summary email (signed with
+ *      that domain's own key).
+ *
+ * Never throws — the whole body is wrapped so every failure (DB lookups,
+ * the send) is logged and swallowed. The caller invokes it fire-and-forget
+ * after the SMTP ack, and the contract holds even without a `.catch`.
+ */
+export async function notifyInboundReceived(input: NotifyInboundInput): Promise<void> {
+  try {
+    /** Loop guard — don't notify on mail from one of our own domains. */
+    const senderDomain = input.from.split("@")[1]?.toLowerCase();
+    if (senderDomain && (await domainExistsByName(senderDomain))) {
+      logger.info("Inbound notify skipped — sender is a registered domain (loop guard)", {
+        from: redactEmail(input.from),
+      });
+      return;
+    }
+
+    /** Distinct recipient domain → first accepted address on it (for display). */
+    const byDomain = new Map<string, string>();
+    for (const addr of input.recipients) {
+      const domainName = addr.split("@")[1]?.toLowerCase();
+      if (domainName && !byDomain.has(domainName)) byDomain.set(domainName, addr);
+    }
+    if (byDomain.size === 0) {
+      logger.debug("Inbound notify skipped — no envelope recipients", {
+        inboundId: input.inboundId,
+      });
+      return;
+    }
+
+    for (const [domainName, recipientAddress] of byDomain) {
+      const domain = await getDomainByName(domainName);
+      if (!domain || !domain.notifyEmail) continue;
+      await sendDomainNotification(domain, recipientAddress, input);
+    }
+  } catch (err) {
+    logger.error("Inbound notification handler error", {
+      inboundId: input.inboundId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Sends a single domain's notification. Isolated in its own try/catch so a
+ * failure for one recipient domain doesn't abort the others, and so the
+ * delivery outcome is reported accurately: `sendMail` resolves and returns
+ * a per-MX `deliveryState` rather than throwing on a bad recipient MX, so
+ * we inspect it and only log success when a group actually reached `sent`.
+ */
+async function sendDomainNotification(
+  domain: Domain,
+  recipientAddress: string,
+  input: NotifyInboundInput,
+): Promise<void> {
+  const notifyEmail = domain.notifyEmail;
+  if (!notifyEmail) return;
+
+  const from = `${config.inboundNotify.fromLocalPart}@${domain.name}`;
+  const dkim = resolveDkim(domain);
+  const messageId = `<${randomBytes(16).toString("hex")}@${config.mail.hostname}>`;
+  const detailUrl = config.appBaseUrl
+    ? `${config.appBaseUrl}/dashboard/inbound/${input.inboundId}`
+    : null;
+
+  const content = buildInboundNotification({
+    to: recipientAddress,
+    from: input.from,
+    subject: input.subject,
+    text: input.text,
+    detailUrl,
+  });
+
+  try {
+    const result = await sendMail({
+      from,
+      to: notifyEmail,
+      subject: content.subject,
+      html: content.html,
+      text: content.text,
+      messageId,
+      dkim,
+    });
+    /** sendMail doesn't throw on a dead recipient MX — it reports per-group
+     *  outcomes. Only claim "sent" when a group actually landed. */
+    const delivered = Object.values(result.deliveryState).some(
+      (g) => g.status === "sent",
+    );
+    if (delivered) {
+      logger.info("Inbound notification sent", {
+        inboundId: input.inboundId,
+        to: redactEmail(notifyEmail),
+        domain: domain.name,
+        signed: !!dkim,
+      });
+    } else {
+      logger.warn("Inbound notification not delivered (no MX group accepted it)", {
+        inboundId: input.inboundId,
+        to: redactEmail(notifyEmail),
+        domain: domain.name,
+      });
+    }
+  } catch (err) {
+    logger.warn("Inbound notification failed to send", {
+      inboundId: input.inboundId,
+      domain: domain.name,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/modules/inbound/services/smtp-receiver.service.ts
+++ b/src/modules/inbound/services/smtp-receiver.service.ts
@@ -6,6 +6,7 @@ import { inboundEmails } from "../models/inbound-email.schema.ts";
 import { generateId } from "../../../utils/id.ts";
 import { dispatchEvent } from "../../webhooks/services/webhook-dispatch.service.ts";
 import { domainExistsByName } from "../../domains/services/domain.service.ts";
+import { notifyInboundReceived } from "./inbound-notify.service.ts";
 import { parseBounce } from "../../bounces/services/bounce-parser.service.ts";
 import { handleParsedBounce } from "../../bounces/services/bounce-handler.service.ts";
 import { persistDmarcReportFromInbound } from "../../dmarc-reports/services/dmarc-handler.service.ts";
@@ -435,6 +436,38 @@ export function start(): void {
             to,
             subject: parsed.subject ?? null,
           });
+
+          /**
+           * Send the per-domain inbound notification (#106), fire-and-forget.
+           * Sits after the bounce/DMARC early-returns, so DSNs and DMARC
+           * reports never trigger it. NOT awaited — a slow notification
+           * (DNS/MX resolution) must never delay the SMTP ack below, which
+           * would risk the upstream MTA timing out and redelivering.
+           *
+           * Domain resolution keys off the **envelope** RCPT TO (the
+           * addresses actually validated + accepted in `onRcptTo`), not the
+           * spoofable `To:` header — so BCC / list mail still notifies the
+           * domain it was received for, and a forged header can't steer
+           * the signing identity. `notifyInboundReceived` never throws; the
+           * `.catch` is a redundant belt.
+           */
+          if (config.inboundNotify.enabled) {
+            const envelopeRecipients = (session.envelope.rcptTo ?? []).map(
+              (r) => r.address,
+            );
+            void notifyInboundReceived({
+              inboundId: id,
+              from,
+              recipients: envelopeRecipients,
+              subject: parsed.subject ?? null,
+              text: parsed.text ?? null,
+            }).catch((err) => {
+              logger.error("Inbound notification dispatch failed", {
+                id,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+          }
 
           callback();
         } catch (error) {

--- a/src/pages/pages.plugin.tsx
+++ b/src/pages/pages.plugin.tsx
@@ -915,6 +915,47 @@ export const pagesPlugin = new Elysia({
   )
 
   /**
+   * POST /dashboard/domains/:id/notify-email
+   * Sets or clears the inbound-notification address for a domain (#106).
+   * An empty submission clears it (disables notifications).
+   */
+  .post(
+    "/domains/:id/notify-email",
+    async ({ params, body, set }) => {
+      const raw = (body.notifyEmail ?? "").trim();
+      /** Empty clears the address; otherwise require a plausible email. */
+      const value = raw === "" ? null : raw;
+      if (value !== null && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+        set.status = 302;
+        set.headers["location"] =
+          `/dashboard/domains/${params.id}?flash=${encodeURIComponent("Enter a valid email address")}&flashType=error`;
+        return "";
+      }
+
+      const updated = await domainService.updateDomainNotifyEmail(params.id, value);
+
+      if (!updated) {
+        set.status = 302;
+        set.headers["location"] =
+          `/dashboard/domains?flash=${encodeURIComponent("Domain not found")}&flashType=error`;
+        return "";
+      }
+
+      const message = value
+        ? "Inbound notifications enabled"
+        : "Inbound notifications disabled";
+      set.status = 302;
+      set.headers["location"] =
+        `/dashboard/domains/${params.id}?flash=${encodeURIComponent(message)}&flashType=success`;
+      return "";
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: t.Object({ notifyEmail: t.Optional(t.String({ maxLength: 255 })) }),
+    },
+  )
+
+  /**
    * GET /dashboard/domains/:id
    * Single domain detail view with DNS verification status.
    */

--- a/src/pages/routes/domain-detail.tsx
+++ b/src/pages/routes/domain-detail.tsx
@@ -85,6 +85,36 @@ export function DomainDetailPage({ domain, flash }: DomainDetailPageProps) {
         </div>
       </div>
 
+      {/* Inbound notifications (#106) */}
+      <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-5 mb-6">
+        <h2 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+          Inbound Notifications
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Get a summary email when mail is received for this domain. Leave empty to
+          disable. Use an external mailbox (not an address on this domain).
+        </p>
+        <form
+          method="POST"
+          action={`/dashboard/domains/${domain.id}/notify-email`}
+          class="flex flex-col sm:flex-row gap-3 sm:items-center"
+        >
+          <input
+            type="email"
+            name="notifyEmail"
+            value={domain.notifyEmail ?? ""}
+            placeholder="ops@yourcompany.com"
+            class="flex-1 px-3 py-2 text-sm bg-white dark:bg-gray-950 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:focus:ring-gray-600"
+          />
+          <button
+            type="submit"
+            class="px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors whitespace-nowrap"
+          >
+            Save
+          </button>
+        </form>
+      </div>
+
       {/* Domain details */}
       <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-5">
         <h2 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">

--- a/test/e2e/dashboard.test.ts
+++ b/test/e2e/dashboard.test.ts
@@ -123,6 +123,7 @@ mock.module("../../src/modules/domains/services/domain.service.ts", () => ({
       verifiedAt: null,
       unsubscribeEmail: null,
       unsubscribeUrl: null,
+      notifyEmail: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     }),

--- a/test/e2e/domains-api.test.ts
+++ b/test/e2e/domains-api.test.ts
@@ -82,6 +82,7 @@ const mockDomain = {
   verifiedAt: null,
   unsubscribeEmail: null as string | null,
   unsubscribeUrl: null as string | null,
+  notifyEmail: null as string | null,
   createdAt: new Date("2024-01-01"),
   updatedAt: new Date("2024-01-01"),
 };

--- a/test/integration/domain.integration.test.ts
+++ b/test/integration/domain.integration.test.ts
@@ -15,10 +15,12 @@ import { eq } from "drizzle-orm";
 import {
   createDomain,
   getDomainById,
+  getDomainByName,
   listDomains,
   domainExistsByName,
   deleteDomain,
   getDkimDnsRecord,
+  updateDomainNotifyEmail,
 } from "../../src/modules/domains/services/domain.service.ts";
 import { isEncryptedSecret, decryptSecret } from "../../src/utils/crypto.ts";
 import { config } from "../../src/config.ts";
@@ -70,6 +72,50 @@ describe("createDomain", () => {
     });
     expect(created.unsubscribeEmail).toBe("noreply@example.com");
     expect(created.unsubscribeUrl).toBe("https://example.com/unsub");
+  });
+
+  test("notify_email defaults to null and can be set at create time (#106)", async () => {
+    const a = await createDomain({ name: "a.example.com" });
+    expect(a.notifyEmail).toBeNull();
+
+    const b = await createDomain({
+      name: "b.example.com",
+      notifyEmail: "ops@external.com",
+    });
+    expect(b.notifyEmail).toBe("ops@external.com");
+  });
+});
+
+describe("getDomainByName (#106)", () => {
+  test("returns the full row (with DKIM material) for an exact name match", async () => {
+    const created = await createDomain({ name: "example.com" });
+    const fetched = await getDomainByName("example.com");
+    expect(fetched?.id).toBe(created.id);
+    /** Carries the encrypted DKIM key so the notify path can sign. */
+    expect(fetched?.dkimPrivateKey).not.toBeNull();
+    expect(fetched?.dkimSelector).toBe("bunmail");
+  });
+
+  test("returns undefined for an unregistered name", async () => {
+    expect(await getDomainByName("not-registered.com")).toBeUndefined();
+  });
+});
+
+describe("updateDomainNotifyEmail (#106)", () => {
+  test("sets and then clears the notify address", async () => {
+    const created = await createDomain({ name: "example.com" });
+
+    const set = await updateDomainNotifyEmail(created.id, "ops@external.com");
+    expect(set?.notifyEmail).toBe("ops@external.com");
+    expect((await getDomainById(created.id))?.notifyEmail).toBe("ops@external.com");
+
+    const cleared = await updateDomainNotifyEmail(created.id, null);
+    expect(cleared?.notifyEmail).toBeNull();
+    expect((await getDomainById(created.id))?.notifyEmail).toBeNull();
+  });
+
+  test("returns undefined when the domain doesn't exist", async () => {
+    expect(await updateDomainNotifyEmail("dom_doesnotexist", "x@y.com")).toBeUndefined();
   });
 });
 

--- a/test/unit/dns-verification.service.test.ts
+++ b/test/unit/dns-verification.service.test.ts
@@ -54,6 +54,7 @@ const baseDomain = {
   verifiedAt: null as Date | null,
   unsubscribeEmail: null as string | null,
   unsubscribeUrl: null as string | null,
+  notifyEmail: null as string | null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/test/unit/domain.serialization.test.ts
+++ b/test/unit/domain.serialization.test.ts
@@ -22,6 +22,7 @@ describe("serializeDomain", () => {
     verifiedAt: new Date("2024-06-01"),
     unsubscribeEmail: null as string | null,
     unsubscribeUrl: null as string | null,
+    notifyEmail: null as string | null,
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
   };
@@ -70,5 +71,11 @@ describe("serializeDomain", () => {
     });
     expect(withOverrides.unsubscribeEmail).toBe("optout@example.com");
     expect(withOverrides.unsubscribeUrl).toBe("https://example.com/unsubscribe?id=abc");
+  });
+
+  test("exposes notifyEmail (null when unset)", () => {
+    expect(serializeDomain(domain).notifyEmail).toBeNull();
+    const withNotify = serializeDomain({ ...domain, notifyEmail: "ops@external.com" });
+    expect(withNotify.notifyEmail).toBe("ops@external.com");
   });
 });

--- a/test/unit/domain.service.test.ts
+++ b/test/unit/domain.service.test.ts
@@ -37,6 +37,7 @@ const baseDomain = {
   dkimSelector: "bunmail",
   unsubscribeEmail: null,
   unsubscribeUrl: null,
+  notifyEmail: null,
   spfVerified: false,
   dkimVerified: false,
   dmarcVerified: false,

--- a/test/unit/get-dkim-dns-record.test.ts
+++ b/test/unit/get-dkim-dns-record.test.ts
@@ -68,6 +68,7 @@ function makeDomain(overrides: Record<string, unknown> = {}) {
     verifiedAt: null,
     unsubscribeEmail: null,
     unsubscribeUrl: null,
+    notifyEmail: null,
     createdAt: new Date("2024-01-01"),
     updatedAt: new Date("2024-01-01"),
     ...overrides,

--- a/test/unit/inbound-notify.test.ts
+++ b/test/unit/inbound-notify.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "bun:test";
+import { buildInboundNotification } from "../../src/modules/inbound/services/inbound-notify.service.ts";
+
+/**
+ * Unit tests for the pure notification-builder (#106). The orchestrator
+ * `notifyInboundReceived` does DB + SMTP I/O and is covered by manual /
+ * integration verification; the builder is the part with branching logic
+ * worth pinning down, and it has no dependencies to mock.
+ */
+describe("buildInboundNotification", () => {
+  const base = {
+    to: "hello@example.com",
+    from: "sender@somewhere.com",
+    subject: "Question about pricing",
+    text: "Hi there, I wanted to ask about your pricing tiers.",
+    detailUrl: "https://mail.example.com/dashboard/inbound/inb_123",
+  };
+
+  test("subject carries recipient + original subject", () => {
+    const { subject } = buildInboundNotification(base);
+    expect(subject).toBe("New email at hello@example.com: Question about pricing");
+  });
+
+  test("falls back to (no subject) when subject is null/blank", () => {
+    expect(buildInboundNotification({ ...base, subject: null }).subject).toBe(
+      "New email at hello@example.com: (no subject)",
+    );
+    expect(buildInboundNotification({ ...base, subject: "   " }).subject).toBe(
+      "New email at hello@example.com: (no subject)",
+    );
+  });
+
+  test("text + html include sender, subject and preview", () => {
+    const { text, html } = buildInboundNotification(base);
+    for (const part of [text, html]) {
+      expect(part).toContain("sender@somewhere.com");
+      expect(part).toContain("Question about pricing");
+      expect(part).toContain("I wanted to ask about your pricing tiers");
+    }
+  });
+
+  test("includes the dashboard link only when detailUrl is provided", () => {
+    const withLink = buildInboundNotification(base);
+    expect(withLink.text).toContain(base.detailUrl);
+    expect(withLink.html).toContain(base.detailUrl);
+
+    const without = buildInboundNotification({ ...base, detailUrl: null });
+    expect(without.text).not.toContain("dashboard/inbound");
+    expect(without.html).not.toContain("dashboard/inbound");
+  });
+
+  test("collapses whitespace and truncates the preview to 200 chars + ellipsis", () => {
+    const long = "word ".repeat(100); // 500 chars, lots of whitespace
+    const { text } = buildInboundNotification({ ...base, text: long });
+    /** The body line is collapsed to single spaces and capped. */
+    const previewLine = text.split("\n").find((l) => l.startsWith("word word"));
+    expect(previewLine).toBeDefined();
+    expect(previewLine!.endsWith("…")).toBe(true);
+    // 200 visible chars + the ellipsis (trimEnd may drop a trailing space first)
+    expect(previewLine!.length).toBeLessThanOrEqual(201);
+  });
+
+  test("omits the preview block when there is no text body", () => {
+    const { text } = buildInboundNotification({ ...base, text: null });
+    expect(text).toContain("From:    sender@somewhere.com");
+    expect(text).toContain("Subject: Question about pricing");
+    /** No stray empty preview content beyond the structured lines. */
+    expect(text).not.toContain("I wanted to ask");
+  });
+
+  test("HTML-escapes attacker-controlled fields in the html part", () => {
+    const { html } = buildInboundNotification({
+      ...base,
+      from: "<script>alert(1)</script>@evil.com",
+      subject: "<img src=x onerror=alert(1)>",
+      text: "<b>bold</b> & dangerous",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;img src=x");
+    expect(html).toContain("&amp; dangerous");
+  });
+});

--- a/test/unit/pages-render.test.ts
+++ b/test/unit/pages-render.test.ts
@@ -64,6 +64,7 @@ const domain = {
   verifiedAt: null,
   unsubscribeEmail: null,
   unsubscribeUrl: null,
+  notifyEmail: null,
   createdAt: now,
   updatedAt: now,
 };
@@ -154,6 +155,14 @@ describe("Dashboard page render smoke tests", () => {
   test("DomainDetailPage", () => {
     const html = String(DomainDetailPage({ domain }));
     expect(html).toContain("example.com");
+    /** Inbound-notification edit form is present (#106). */
+    expect(html).toContain(`/dashboard/domains/${domain.id}/notify-email`);
+    expect(html).toContain('name="notifyEmail"');
+    /** A configured address pre-fills the input. */
+    const withNotify = String(
+      DomainDetailPage({ domain: { ...domain, notifyEmail: "ops@external.com" } }),
+    );
+    expect(withNotify).toContain("ops@external.com");
   });
 
   test("EmailsPage with various states", () => {


### PR DESCRIPTION
Closes #106.

## Summary

When the SMTP receiver accepts an inbound message for a domain that has a `notify_email` set, BunMail now sends a "you have new mail" summary email (sender, subject, ~200-char preview, and a dashboard link when `APP_BASE_URL` is set) to that address — sent **from** `<INBOUND_NOTIFY_FROM_LOCAL>@<recipient domain>` (default `notifications@…`) and **DKIM-signed with the recipient domain's own key**, so it passes the same SPF/DKIM the operator already set up for outbound.

## Why per-domain

A full-codebase read confirmed two things that shaped the design:
- **Inbound already fires a webhook** (`email.received`) — so the missing piece was an *email* notification, not a webhook. The webhook taxonomy is left untouched.
- **There is no API-key ownership model for inbound** (`inbound_emails` / `domains` / `api_keys` carry no linking FK; inbound is routed purely by recipient domain). So "notify the owner" has no owner to resolve — the notify target is resolved from the recipient domain's new nullable `notify_email` column.

## How it works

- Fired **fire-and-forget** right after the inbound row is stored, so it never delays the SMTP ack (no upstream-redelivery risk).
- **Domain resolution keys off the envelope RCPT TO** (the addresses actually validated + accepted in `onRcptTo`), not the spoofable `To:` header — so BCC / list mail still notifies the domain it was received for, a forged header can't steer the signing identity, and a message addressed to several registered domains notifies each notify-enabled one.
- **Bounces (DSNs) and DMARC reports** early-return before the hook, so they never trigger a notification.
- **Loop guard:** mail whose sender domain is itself a registered BunMail domain is skipped (a looped notification can't re-notify).
- Never throws into the receive path; "sent" is logged only when a recipient MX group actually accepted the message (otherwise a "not delivered" warning).

## Changes

- **Schema:** `domains.notify_email varchar(255) NULL` + migration `0008_new_darwin.sql`.
- **Domain service:** `getDomainByName`, `updateDomainNotifyEmail`; serializer + optional `notifyEmail` on the create-domain DTO/route.
- **New** `src/modules/inbound/services/inbound-notify.service.ts` — pure summary builder + orchestrator (DKIM resolved from the domain's own encrypted key via `decryptSecret`; out-of-band send, no `emails` row).
- **Receiver hook** in `smtp-receiver.service.ts`.
- **Config/env:** `INBOUND_NOTIFY_ENABLED` (default true, kill switch), `INBOUND_NOTIFY_FROM_LOCAL` (default `notifications`), optional `APP_BASE_URL` (dashboard link).
- **Dashboard:** editable notify-email field on the domain detail page + `POST /dashboard/domains/:id/notify-email`.
- **Docs:** `docs/inbound.md`, `docs/domains.md`, `ARCHITECTURE.md` (schema), `docs/api.md`, `docs/self-hosting.md`, `.env.example`, `README.md`, `CHANGELOG.md`.
- **Tests:** builder unit tests (incl. HTML-escaping), `getDomainByName` / `updateDomainNotifyEmail` integration round-trips, domain-detail render assertions, + `notify_email` added to existing domain fixtures.

## Reviewed

Ran an adversarial review pass before pushing. Confirmed findings applied: resolve from envelope (the high-severity bug — fixed missed/misdirected notifications on BCC/cross-domain), make `notifyInboundReceived` genuinely never-throw (wrap DB lookups), and log success only on real delivery.

## Known v1 limitations (tracked as follow-ups on #106)

- The inbound path does **not** verify SPF/DKIM/DMARC on received mail (a property of the whole inbound subsystem) — notification contents are unauthenticated, like the inbox itself. HTML is escaped; headers go through Nodemailer.
- No per-`notify_email` throttle/digest — volume is bounded only by the SMTP per-IP rate limit. True forwarding (SRS/ARC) is also deferred.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun test test/unit test/e2e` — 363 pass.
- [x] `bun run test:integration` — 100 pass.
- [ ] Manual: set a domain's notify email in the dashboard, send a test message to the SMTP receiver for that domain → confirm a DKIM-signed summary email arrives with from/subject/preview (+ link when `APP_BASE_URL` set).
- [ ] Manual: confirm a DSN/bounce and a DMARC report do NOT notify; confirm clearing the field disables it.