### PR TITLE
fix(test): complete config mock in redact.test.ts to fix flaky unit CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: refresh pinned GitHub Actions in the `github-actions` group (#117, #119).** Two Dependabot batches since v0.7.0. #117 bumped `actions/checkout` 6.0.3→7.0.0 and `actions/cache` 5.0.5→6.1.0 (major versions) plus `softprops/action-gh-release` 3.0.0→3.0.1. #119 re-pinned `github/codeql-action` (init/autobuild/analyze/upload-sarif), `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`, and `softprops/action-gh-release` to their latest SHAs on the same major tags. CI workflow files only (`.github/workflows/`); no runtime, API, schema, or env changes.
+
+### Fixed
+
+- **Flaky unit CI: incomplete `config` mock leaked across test files (#121).** `test/unit/redact.test.ts` mocked `src/config.ts` with a stub that only defined `logRedactPii`. Because Bun's `mock.module` leaks globally across test files, a later fresh import of `src/db/index.ts` — which evaluates `new SQL(config.database.url)` at module load — crashed with `undefined is not an object (evaluating 'config.database.url')` under CI's Linux test-file ordering (green on macOS, red on CI). The stub now also populates `database.url`, so eagerly-evaluated consumers survive the leaked mock. Test-only; no source or behaviour change. Closes #121.
+
 ## [0.7.0] - 2026-06-18
 
 ### Added

--- a/test/unit/redact.test.ts
+++ b/test/unit/redact.test.ts
@@ -11,8 +11,19 @@ import { describe, test, expect, mock } from "bun:test";
 /* ─── Mock the config module so we can flip the flag ─── */
 let redactPiiFlag = true;
 
+/**
+ * NOTE: Bun's `mock.module` leaks globally across test files — a mock
+ * registered here stays active for every file Bun loads afterwards. So
+ * this stub must be a *complete* enough `config` that any module which
+ * eagerly reads it at import time still works under the leaked mock.
+ * In particular `src/db/index.ts` evaluates `new SQL(config.database.url)`
+ * at module load; a stub without `database` crashes a later file with
+ * "undefined is not an object (evaluating 'config.database.url')" under
+ * CI's test-file ordering. Keep `database.url` populated. (#119 CI red)
+ */
 mock.module("../../src/config.ts", () => ({
   config: {
+    database: { url: "postgres://test:test@localhost:5432/test" },
     get logRedactPii() {
       return redactPiiFlag;
     },


### PR DESCRIPTION
## Why

`main`'s `CI` / `Test (unit)` job went red (first surfaced on the #119 merge, then on a manual re-run) with:

```
# Unhandled error between tests
6 | const client = new SQL(config.database.url);
TypeError: undefined is not an object (evaluating 'config.database.url')
1 fail, 1 error → exit code 1
```

Green locally (macOS) and on PR checks, red on CI (Linux) — the signature of an order-dependent test-mock leak. Full diagnosis in #121.

## Root cause

`test/unit/redact.test.ts` mocked `src/config.ts` with a stub that only defined `logRedactPii`. Bun's `mock.module` **leaks globally across test files**, so once redact runs, a later fresh import of `src/db/index.ts` — which evaluates `new SQL(config.database.url)` at module load — sees a `config` with no `database` and throws. Whether it triggers depends on Bun's test-file glob order, which differs between macOS and CI's Linux.

Not caused by the Dependabot bumps (#117 / #119) — those touched only `.github/workflows/` SHAs. They merely surfaced a latent flake.

## Fix

Populate `database.url` in the mock stub so eagerly-evaluated consumers survive the leak (matches what the other config-mocking unit tests already do), with a comment explaining the footgun. Test-only — no source or behaviour change.

## Verification

- `bun test test/unit` → 319 pass, 0 fail
- Full pre-commit suite (unit + e2e + 100 integration) green
- `bunx tsc --noEmit`, `eslint --fix`, `prettier` all clean (husky)

## Changelog

`[Unreleased]` now records this fix (#121) plus the two Dependabot CI-action batches that merged since v0.7.0 without a changelog note (#117, #119).

Closes #121.