### PR TITLE
fix(deps): bump linkify-it to 5.0.2 — CVE-2026-59887 (HIGH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Bump `linkify-it` 5.0.1 → 5.0.2 — CVE-2026-59887 (HIGH).** Patches a quadratic-complexity DoS in linkify-it's `mailto:` validator, pulled in transitively via `mailparser`. Forced through an `overrides` entry (the same mechanism used for `nodemailer`); only 5.0.2 resolves in the lockfile, clearing the Trivy HIGH finding. No code or behaviour change.
+
 ## [0.8.0] - 2026-07-19
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
     "defu": "^6.1.7",
     "file-type": "^22.0.1",
     "flatted": "^3.4.2",
+    "linkify-it": "^5.0.2",
     "nodemailer": "9.0.1",
     "picomatch": "^4.0.4",
     "yaml": "^2.8.4",
@@ -581,7 +582,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+    "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
 
     "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "yaml": "^2.8.4",
     "file-type": "^22.0.1",
     "brace-expansion": "^5.0.5",
-    "nodemailer": "9.0.1"
+    "nodemailer": "9.0.1",
+    "linkify-it": "^5.0.2"
   }
 }


### PR DESCRIPTION
## What

Patches **CVE-2026-59887** (HIGH) — a quadratic-complexity DoS in `linkify-it`'s `mailto:` validator. `linkify-it@5.0.1` is pulled in transitively via **`mailparser`** (used by the inbound + SMTP-submission parsers). Trivy's DB started flagging it, failing the `Trivy filesystem scan` / `Trivy image scan` jobs on every build (not a regression from any code change — a newly-disclosed CVE).

## Fix

Add `"linkify-it": "^5.0.2"` to `overrides` (same mechanism already used to force `nodemailer`). After `bun install`, only `linkify-it@5.0.2` resolves in the lockfile (mailparser's `5.0.1` spec is overridden), so no vulnerable copy ships. No code or behaviour change.

## Verify

- `bun.lock`: the single resolved `linkify-it` entry is `5.0.2`.
- Full pre-commit suite green (unit + e2e + 117 integration).
- This clears the Trivy HIGH finding for `main` (and unblocks the informational Trivy jobs on open PRs).

Note: Trivy isn't a required check (only `ci` + `Analyze` are), so this wasn't blocking merges — but it's a real HIGH CVE, so worth patching promptly.