### PR TITLE
fix(webhooks): SSRF guard on webhook URLs — create + delivery (#128)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,3 +177,7 @@ TOMBSTONE_RETENTION_DAYS=90
 # so operators can audit "did this event ever land?" months later.
 # Default: 30
 WEBHOOK_DELIVERY_RETENTION_DAYS=30
+# SSRF guard (#128): webhook URLs must be https and must not resolve to a
+# private/loopback/link-local/metadata address. Set to true to also allow
+# plaintext http targets (the private-range block still applies). Default: false
+WEBHOOK_ALLOW_INSECURE_HTTP=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Webhook SSRF guard (#128).** Webhook URLs are tenant-supplied and fetched server-side, with the response read back through the delivery API — previously an unvalidated, *exfiltrating* SSRF (register `http://169.254.169.254/…` or `http://127.0.0.1:5432`, get cloud-metadata creds / internal responses back). Now every webhook URL is validated **at creation** (REST + dashboard) **and re-validated before each delivery attempt** (TOCTOU): it must be `https` (set `WEBHOOK_ALLOW_INSECURE_HTTP=true` to also allow `http`), and its host is **DNS-resolved and rejected if any address is private/loopback/link-local/ULA/CGNAT/metadata** (`127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `::1`, `fc00::/7`, `fe80::/10`, v4-mapped, …). Delivery uses `redirect: "manual"`, so a 3xx into an internal address can't bypass the check (it's counted as a failed delivery). Create-time rejection returns **HTTP 422 `WEBHOOK_URL_BLOCKED`**. New env: `WEBHOOK_ALLOW_INSECURE_HTTP` (default `false`).
 - **Bump `linkify-it` 5.0.1 → 5.0.2 — CVE-2026-59887 (HIGH).** Patches a quadratic-complexity DoS in linkify-it's `mailto:` validator, pulled in transitively via `mailparser`. Forced through an `overrides` entry (the same mechanism used for `nodemailer`); only 5.0.2 resolves in the lockfile, clearing the Trivy HIGH finding. No code or behaviour change.
 
 ## [0.8.0] - 2026-07-19

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -122,6 +122,7 @@ Because outbound mail is DKIM-signed by its sender domain, an API key that can s
 ### Webhooks
 
 - Outgoing webhook payloads are HMAC-SHA256 signed using the per-webhook secret. The signature covers `<unix-timestamp>.<raw-body>`; the timestamp is shipped in the `X-BunMail-Timestamp` header and the signature in `X-BunMail-Signature` (#43). Each retry attempt is signed with a fresh timestamp, so a replayed delivery from yesterday fails the freshness check on the receiver. Recommended consumer check: `|now - timestamp| < 5 min`.
+- **SSRF guard (#128).** Webhook URLs are tenant-supplied and fetched server-side, and the response is read back through the delivery API — so an unvalidated URL is an *exfiltrating* SSRF. `src/utils/ssrf-guard.ts` validates every URL **at creation and again before each delivery attempt** (DNS can rebind): scheme must be `https` (or `http` only if `WEBHOOK_ALLOW_INSECURE_HTTP=true`), and the host is resolved and rejected if any address is private/loopback/link-local/ULA/CGNAT/metadata (incl. `169.254.169.254` and v4-mapped v6). Delivery uses `redirect: "manual"` so a 3xx into an internal address can't bypass the check. **Residual:** the guard resolves DNS then fetches (a small TOCTOU window remains against a sub-second rebind); an egress firewall / proxy is the belt-and-suspenders control for hostile multi-tenant use.
 
 ### Dashboard XSS
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -550,5 +550,5 @@ Some responses carry additional structured fields — e.g. suppression-list reje
 | 401    | Missing or invalid token                        |
 | 403    | Authenticated but not permitted — `From` not in the key's allowed-senders list (`UNAUTHORIZED_SENDER`), or a restricted key calling an admin-only endpoint (`ADMIN_REQUIRED`, #130) |
 | 404    | Resource not found                              |
-| 422    | Validation error                                |
+| 422    | Validation error — includes webhook URL rejected by the SSRF guard (`WEBHOOK_URL_BLOCKED`, #128) |
 | 429    | Rate limit exceeded                             |

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2,6 +2,16 @@
 
 Sends real-time event notifications to registered HTTP endpoints when email status changes.
 
+## URL requirements & SSRF guard (#128)
+
+Because BunMail fetches webhook URLs server-side (and the response is readable via the delivery API), URLs are validated at **creation** and re-validated **before every delivery attempt**:
+
+- Must be **`https`**. To allow plaintext `http` targets, set `WEBHOOK_ALLOW_INSECURE_HTTP=true` (the private-range block below still applies).
+- The host is **DNS-resolved**, and the URL is **rejected if any resolved address is private/loopback/link-local/ULA/CGNAT/metadata** — `127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (incl. `169.254.169.254`), `100.64/10`, `::1`, `fc00::/7`, `fe80::/10`, and v4-mapped equivalents.
+- **Redirects are not followed** (`redirect: "manual"`) — a 3xx counts as a failed delivery, so it can't bounce into an internal address.
+
+A rejected URL at create time returns **HTTP 422** `{ "code": "WEBHOOK_URL_BLOCKED" }`. A URL that only becomes internal later (DNS rebinding, or a row created before this guard) is caught at delivery time and recorded as a failed attempt.
+
 ## Module Layout
 
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -354,5 +354,14 @@ export const config = {
      * months after the fact.
      */
     retentionDays: parseInt(optionalEnv("WEBHOOK_DELIVERY_RETENTION_DAYS", "30"), 10),
+
+    /**
+     * SSRF guard (#128). Webhook URLs must be `https` and must not resolve
+     * to a private/loopback/link-local/metadata address. Set
+     * `WEBHOOK_ALLOW_INSECURE_HTTP=true` to also permit `http:` targets
+     * (e.g. an internal-but-public receiver without TLS) — the
+     * private-range block still applies either way.
+     */
+    allowInsecureHttp: optionalEnv("WEBHOOK_ALLOW_INSECURE_HTTP", "false") === "true",
   },
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { suppressionsPlugin } from "./modules/suppressions/suppressions.plugin.t
 import { smtpSubmissionPlugin } from "./modules/smtp-submission/smtp-submission.plugin.ts";
 import { SuppressedRecipientError } from "./modules/suppressions/errors.ts";
 import { UnauthorizedSenderError } from "./modules/api-keys/errors.ts";
+import { BlockedUrlError } from "./utils/ssrf-guard.ts";
 import { dmarcReportsPlugin } from "./modules/dmarc-reports/dmarc-reports.plugin.ts";
 import { pagesPlugin } from "./pages/pages.plugin.tsx";
 import { landingPlugin } from "./pages/landing.plugin.tsx";
@@ -153,6 +154,15 @@ const app = new Elysia()
         code: "UNAUTHORIZED_SENDER",
         sender: error.sender,
       };
+    }
+
+    /**
+     * Webhook URL rejected by the SSRF guard (#128) → 422. Surfaces at
+     * create time so the caller sees why the URL was refused.
+     */
+    if (error instanceof BlockedUrlError) {
+      set.status = 422;
+      return { success: false, error: error.message, code: "WEBHOOK_URL_BLOCKED" };
     }
 
     const message = error instanceof Error ? error.message : "Internal server error";

--- a/src/modules/webhooks/services/webhook-delivery.service.ts
+++ b/src/modules/webhooks/services/webhook-delivery.service.ts
@@ -33,6 +33,8 @@ import { webhooks } from "../models/webhook.schema.ts";
 import { signPayload } from "./webhook-dispatch.service.ts";
 import { logger } from "../../../utils/logger.ts";
 import { generateId } from "../../../utils/id.ts";
+import { assertPublicWebhookUrl } from "../../../utils/ssrf-guard.ts";
+import { config } from "../../../config.ts";
 import type { WebhookEventType } from "../types/webhook.types.ts";
 
 /**
@@ -281,6 +283,23 @@ export async function performHttpAttempt(opts: {
   const sigTimestamp = Math.floor(Date.now() / 1000).toString();
   const signature = signPayload(sigTimestamp, opts.body, opts.secret);
 
+  /**
+   * SSRF re-validation at delivery time (#128). The URL was checked at
+   * create, but DNS can change (rebinding / TOCTOU) and rows created before
+   * this guard existed were never checked — so re-resolve and re-validate
+   * on every attempt. A blocked URL is a failed attempt, not a fetch.
+   */
+  try {
+    await assertPublicWebhookUrl(opts.url, config.webhookDelivery.allowInsecureHttp);
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+      bodyPreview: null,
+    };
+  }
+
   try {
     const response = await fetchFn(opts.url, {
       method: "POST",
@@ -291,6 +310,12 @@ export async function performHttpAttempt(opts: {
         "X-BunMail-Event": opts.event,
       },
       body: opts.body,
+      /**
+       * Never follow redirects (#128) — a 3xx `Location` into an internal
+       * address (169.254.169.254, 127.0.0.1, …) would bypass the pre-fetch
+       * host check. A redirect is treated as a non-2xx delivery failure.
+       */
+      redirect: "manual",
       signal: AbortSignal.timeout(opts.timeoutMs ?? ATTEMPT_TIMEOUT_MS),
     });
 

--- a/src/modules/webhooks/services/webhook.service.ts
+++ b/src/modules/webhooks/services/webhook.service.ts
@@ -4,6 +4,8 @@ import { db } from "../../../db/index.ts";
 import { webhooks } from "../models/webhook.schema.ts";
 import { generateId } from "../../../utils/id.ts";
 import { logger } from "../../../utils/logger.ts";
+import { assertPublicWebhookUrl } from "../../../utils/ssrf-guard.ts";
+import { config } from "../../../config.ts";
 import type { Webhook, CreateWebhookInput } from "../types/webhook.types.ts";
 
 /**
@@ -16,6 +18,14 @@ export async function createWebhook(
   input: CreateWebhookInput,
   apiKeyId: string,
 ): Promise<{ webhook: Webhook; secret: string }> {
+  /**
+   * SSRF guard (#128): reject URLs that aren't https (unless http is opted
+   * in) or that resolve to a private/loopback/link-local/metadata address,
+   * before we ever store or deliver to them. Throws `BlockedUrlError`,
+   * mapped to HTTP 422 by the global error handler.
+   */
+  await assertPublicWebhookUrl(input.url, config.webhookDelivery.allowInsecureHttp);
+
   const id = generateId("whk");
   const secret = randomBytes(32).toString("hex");
 

--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -1,0 +1,149 @@
+import { lookup } from "dns/promises";
+import { isIP } from "net";
+
+/**
+ * SSRF guard for outbound webhook delivery (#128).
+ *
+ * Webhook URLs are tenant-supplied and fetched server-side, and the
+ * response is read back through the API — so an unvalidated URL is a
+ * classic exfiltrating SSRF (cloud metadata at 169.254.169.254, internal
+ * services on 127/10/172.16/192.168, etc.). This module validates a URL's
+ * scheme and resolves its host, rejecting any that maps to a
+ * private/loopback/link-local/ULA/metadata address.
+ *
+ * Config-free by design (the caller passes `allowHttp`) so it unit-tests
+ * with no environment and no `mock.module`.
+ */
+
+/** Thrown when a URL is refused by the guard. Callers map it to 4xx / a failed delivery. */
+export class BlockedUrlError extends Error {
+  override readonly name = "BlockedUrlError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/* ─── IP range checks ─── */
+
+/** Parses a dotted-quad IPv4 string to a uint32, or null if malformed. */
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const o = Number(p);
+    if (o > 255) return null;
+    n = (n << 8) | o;
+  }
+  return n >>> 0;
+}
+
+/** True if an IPv4 address is in a private / loopback / link-local / reserved range. */
+function isBlockedIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  if (n === null) return true; // unparseable → refuse
+  const inRange = (base: string, bits: number): boolean => {
+    const b = ipv4ToInt(base)!;
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (n & mask) === (b & mask);
+  };
+  return (
+    inRange("0.0.0.0", 8) || // "this host"
+    inRange("10.0.0.0", 8) || // private
+    inRange("100.64.0.0", 10) || // CGNAT
+    inRange("127.0.0.0", 8) || // loopback
+    inRange("169.254.0.0", 16) || // link-local (incl. 169.254.169.254 cloud metadata)
+    inRange("172.16.0.0", 12) || // private
+    inRange("192.0.0.0", 24) || // IETF protocol assignments
+    inRange("192.168.0.0", 16) || // private
+    inRange("198.18.0.0", 15) || // benchmarking
+    inRange("224.0.0.0", 4) || // multicast
+    inRange("240.0.0.0", 4) // reserved / broadcast
+  );
+}
+
+/** True if an IPv6 address is loopback / unspecified / ULA / link-local (or a blocked v4-mapped addr). */
+function isBlockedIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase().split("%")[0]!; // strip zone id
+  if (addr === "::1" || addr === "::") return true;
+  // IPv4-mapped (::ffff:1.2.3.4) or v4-in-v6 — extract the embedded v4.
+  const v4 = addr.match(/(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (v4) return isBlockedIpv4(v4[1]!);
+  const first = parseInt(addr.split(":")[0] || "0", 16);
+  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 ULA
+  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  return false;
+}
+
+/** True if the resolved IP is one webhook delivery must never connect to. */
+export function isBlockedIp(ip: string): boolean {
+  const v = isIP(ip);
+  if (v === 4) return isBlockedIpv4(ip);
+  if (v === 6) return isBlockedIpv6(ip);
+  return true; // not a valid IP → refuse
+}
+
+/* ─── URL validation ─── */
+
+/**
+ * Validates a webhook URL and throws {@link BlockedUrlError} if it must not
+ * be fetched. Checks the scheme, then **resolves the host via DNS** and
+ * rejects if *any* resolved address is private/loopback/link-local/etc. —
+ * so a public hostname that resolves (or later re-resolves, TOCTOU) to an
+ * internal IP is caught too.
+ *
+ * @param rawUrl   The URL to validate.
+ * @param allowHttp Permit `http:` in addition to `https:` (operator opt-in).
+ */
+export async function assertPublicWebhookUrl(
+  rawUrl: string,
+  allowHttp = false,
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new BlockedUrlError("Webhook URL is not a valid absolute URL.");
+  }
+
+  const scheme = url.protocol.toLowerCase();
+  if (scheme !== "https:" && !(allowHttp && scheme === "http:")) {
+    throw new BlockedUrlError(
+      allowHttp
+        ? "Webhook URL must use http or https."
+        : "Webhook URL must use https (set WEBHOOK_ALLOW_INSECURE_HTTP=true to allow http).",
+    );
+  }
+
+  const host = url.hostname;
+  if (!host) throw new BlockedUrlError("Webhook URL has no host.");
+
+  /** If the host is a literal IP, check it directly (no DNS). */
+  if (isIP(host)) {
+    if (isBlockedIp(host)) {
+      throw new BlockedUrlError(
+        `Webhook URL host ${host} is a private/reserved address.`,
+      );
+    }
+    return;
+  }
+
+  /** Resolve every A/AAAA record and reject if ANY is blocked. */
+  let addresses: { address: string }[];
+  try {
+    addresses = await lookup(host, { all: true });
+  } catch {
+    throw new BlockedUrlError(`Webhook URL host "${host}" could not be resolved.`);
+  }
+  if (addresses.length === 0) {
+    throw new BlockedUrlError(`Webhook URL host "${host}" resolved to no addresses.`);
+  }
+  for (const { address } of addresses) {
+    if (isBlockedIp(address)) {
+      throw new BlockedUrlError(
+        `Webhook URL host "${host}" resolves to a private/reserved address (${address}).`,
+      );
+    }
+  }
+}

--- a/test/integration/inbound-bounce-flow.integration.test.ts
+++ b/test/integration/inbound-bounce-flow.integration.test.ts
@@ -154,7 +154,7 @@ describe("inbound DSN → bounce handler — end-to-end (#35 bullets 4 + 5)", ()
     });
     await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/bounce",
+      url: "https://93.184.216.34/bounce",
       events: ["email.bounced"],
     });
 
@@ -188,7 +188,7 @@ describe("inbound DSN → bounce handler — end-to-end (#35 bullets 4 + 5)", ()
     await waitForDispatch();
     expect(captured).toHaveLength(1);
     const req = captured[0]!;
-    expect(req.url).toBe("https://hook.example.com/bounce");
+    expect(req.url).toBe("https://93.184.216.34/bounce");
     expect(req.method).toBe("POST");
     expect(req.headers["x-bunmail-event"]).toBe("email.bounced");
     expect(req.headers["x-bunmail-signature"]).toMatch(/^[a-f0-9]{64}$/);
@@ -214,7 +214,7 @@ describe("inbound DSN → bounce handler — end-to-end (#35 bullets 4 + 5)", ()
     });
     await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/bounce",
+      url: "https://93.184.216.34/bounce",
       events: ["email.bounced"],
     });
 
@@ -271,7 +271,7 @@ describe("inbound DSN → bounce handler — end-to-end (#35 bullets 4 + 5)", ()
     });
     await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/bounce",
+      url: "https://93.184.216.34/bounce",
       events: ["email.bounced"],
     });
 
@@ -305,7 +305,7 @@ describe("inbound DSN → bounce handler — end-to-end (#35 bullets 4 + 5)", ()
     const { id: apiKeyId } = await seed.apiKey();
     await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/bounce",
+      url: "https://93.184.216.34/bounce",
       events: ["email.bounced"],
     });
 

--- a/test/integration/webhook-delivery.integration.test.ts
+++ b/test/integration/webhook-delivery.integration.test.ts
@@ -65,7 +65,7 @@ describe("enqueueDelivery — initial state", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
 
@@ -102,7 +102,7 @@ describe("worker poll cycle — happy path (2xx response → delivered)", () => 
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
       secret: "unit-test-secret",
     });
@@ -116,7 +116,7 @@ describe("worker poll cycle — happy path (2xx response → delivered)", () => 
 
     /** Captured one HTTP request with the right shape. */
     expect(captured).toHaveLength(1);
-    expect(captured[0]?.url).toBe("https://hook.example.com/x");
+    expect(captured[0]?.url).toBe("https://93.184.216.34/x");
     expect(captured[0]?.headers.get("x-bunmail-event")).toBe("email.sent");
     expect(captured[0]?.headers.get("x-bunmail-signature")).toMatch(/^[a-f0-9]{64}$/);
     expect(captured[0]?.headers.get("x-bunmail-timestamp")).toMatch(/^\d{10}$/);
@@ -136,7 +136,7 @@ describe("worker poll cycle — non-2xx response reschedules with backoff", () =
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const before = Date.now();
@@ -165,7 +165,7 @@ describe("worker poll cycle — non-2xx response reschedules with backoff", () =
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: deliveryId } = await enqueueDelivery({
@@ -190,7 +190,7 @@ describe("worker poll cycle — exhausting retries flips status=failed", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: deliveryId } = await enqueueDelivery({
@@ -227,7 +227,7 @@ describe("worker poll cycle — only claims due rows", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: dueId } = await enqueueDelivery({ webhookId, envelope: envelope() });
@@ -262,7 +262,7 @@ describe("worker poll cycle — concurrent workers see disjoint claims", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const ids: string[] = [];
@@ -302,7 +302,7 @@ describe("worker poll cycle — webhook deactivated after enqueue is skipped + m
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: deliveryId } = await enqueueDelivery({
@@ -328,7 +328,7 @@ describe("replayDelivery — resets a failed row to pending", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: deliveryId } = await enqueueDelivery({
@@ -369,7 +369,7 @@ describe("replayDelivery — resets a failed row to pending", () => {
     const { id: keyB } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId: keyA,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: deliveryId } = await enqueueDelivery({
@@ -417,7 +417,7 @@ describe("listDeliveriesForWebhook — pagination + status filter + tenant scopi
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
 
@@ -474,7 +474,7 @@ describe("purgeOldDeliveries — retention cleanup", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     const { id: oldDelivered } = await enqueueDelivery({
@@ -540,14 +540,14 @@ describe("performHttpAttempt — re-signs per attempt", () => {
      *  clock by sleeping ~1.1s between calls so the unix-second
      *  timestamps differ. */
     await performHttpAttempt({
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       secret: "s",
       body: "{}",
       event: "email.sent",
     });
     await new Promise((r) => setTimeout(r, 1_100));
     await performHttpAttempt({
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       secret: "s",
       body: "{}",
       event: "email.sent",
@@ -565,7 +565,7 @@ describe("CASCADE on webhook delete — deliveries vanish too", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { id: webhookId } = await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com/x",
+      url: "https://93.184.216.34/x",
       events: ["email.sent"],
     });
     for (let i = 0; i < 3; i++) {

--- a/test/integration/webhook-dispatch.integration.test.ts
+++ b/test/integration/webhook-dispatch.integration.test.ts
@@ -89,7 +89,7 @@ describe("createWebhook + listWebhooks + deleteWebhook (DB CRUD)", () => {
   test("createWebhook persists with a 64-char secret + event subscription", async () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { webhook, secret } = await createWebhook(
-      { url: "https://example.com/hook", events: ["email.sent"] },
+      { url: "https://93.184.216.34/hook", events: ["email.sent"] },
       apiKeyId,
     );
     expect(webhook.id).toMatch(/^whk_/);
@@ -99,7 +99,7 @@ describe("createWebhook + listWebhooks + deleteWebhook (DB CRUD)", () => {
       .select()
       .from(webhooks)
       .where(eq(webhooks.id, webhook.id));
-    expect(persisted?.url).toBe("https://example.com/hook");
+    expect(persisted?.url).toBe("https://93.184.216.34/hook");
     expect(persisted?.events).toEqual(["email.sent"]);
     expect(persisted?.isActive).toBe(true);
   });
@@ -161,12 +161,12 @@ describe("dispatchEvent — end-to-end", () => {
     const { id: apiKeyId } = await seed.apiKey();
     const { secret: secret1 } = await seed.webhook({
       apiKeyId,
-      url: "https://hook1.example.com",
+      url: "https://93.184.216.34",
       events: ["email.bounced"],
     });
     const { secret: secret2 } = await seed.webhook({
       apiKeyId,
-      url: "https://hook2.example.com",
+      url: "https://93.184.216.35",
       events: ["email.bounced"],
     });
 
@@ -179,7 +179,7 @@ describe("dispatchEvent — end-to-end", () => {
 
     expect(captured).toHaveLength(2);
     const urls = captured.map((c) => c.url).sort();
-    expect(urls).toEqual(["https://hook1.example.com", "https://hook2.example.com"]);
+    expect(urls).toEqual(["https://93.184.216.34", "https://93.184.216.35"]);
 
     /** Both deliveries share the same JSON body (same event payload). */
     const body1 = JSON.parse(captured[0]!.body);
@@ -210,7 +210,7 @@ describe("dispatchEvent — end-to-end", () => {
     /** Subscribed only to email.sent — should not get email.bounced. */
     await seed.webhook({
       apiKeyId,
-      url: "https://hook.example.com",
+      url: "https://93.184.216.34",
       events: ["email.sent"],
     });
 

--- a/test/integration/webhook-ssrf.integration.test.ts
+++ b/test/integration/webhook-ssrf.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration tests for the webhook SSRF guard (#128) against a real
+ * Postgres + real config. Uses literal IPs (no DNS) so it's deterministic.
+ * Covers: rejection at create, and re-validation (+ no fetch, + manual
+ * redirect) at delivery time.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { createWebhook } from "../../src/modules/webhooks/services/webhook.service.ts";
+import { performHttpAttempt } from "../../src/modules/webhooks/services/webhook-delivery.service.ts";
+import { BlockedUrlError } from "../../src/utils/ssrf-guard.ts";
+import { truncateAll, seed, db } from "./_helpers.ts";
+import { webhooks } from "../../src/modules/webhooks/models/webhook.schema.ts";
+
+beforeEach(async () => {
+  await truncateAll();
+});
+
+describe("createWebhook — SSRF guard", () => {
+  test("rejects cloud-metadata / private / loopback URLs (nothing stored)", async () => {
+    const { id: apiKeyId } = await seed.apiKey({ isAdmin: true });
+
+    for (const url of [
+      "http://169.254.169.254/latest/meta-data/",
+      "https://10.0.0.5/hook",
+      "https://127.0.0.1/hook",
+    ]) {
+      await expect(
+        createWebhook({ url, events: ["email.sent"] }, apiKeyId),
+      ).rejects.toBeInstanceOf(BlockedUrlError);
+    }
+
+    const rows = await db.select().from(webhooks).where(eq(webhooks.apiKeyId, apiKeyId));
+    expect(rows).toHaveLength(0);
+  });
+
+  test("rejects http when insecure http isn't opted in (default)", async () => {
+    const { id: apiKeyId } = await seed.apiKey({ isAdmin: true });
+    await expect(
+      createWebhook({ url: "http://1.1.1.1/hook", events: ["email.sent"] }, apiKeyId),
+    ).rejects.toThrow(/https/);
+  });
+
+  test("accepts a public https URL", async () => {
+    const { id: apiKeyId } = await seed.apiKey({ isAdmin: true });
+    const { webhook } = await createWebhook(
+      { url: "https://1.1.1.1/hook", events: ["email.sent"] },
+      apiKeyId,
+    );
+    expect(webhook.url).toBe("https://1.1.1.1/hook");
+  });
+});
+
+describe("performHttpAttempt — delivery-time re-validation", () => {
+  const base = { secret: "s", body: "{}", event: "email.sent" };
+
+  test("does NOT fetch a blocked URL; returns a failed outcome", async () => {
+    let fetchCalled = false;
+    const spyFetch = (() => {
+      fetchCalled = true;
+      throw new Error("fetch must not be called for a blocked URL");
+    }) as unknown as typeof fetch;
+
+    const outcome = await performHttpAttempt({
+      ...base,
+      url: "http://169.254.169.254/latest/meta-data/",
+      fetchImpl: spyFetch,
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toMatch(/private|reserved|https/i);
+  });
+
+  test("fetches an allowed URL with redirect:'manual'", async () => {
+    let seenInit: RequestInit | undefined;
+    const stubFetch = ((_url: string, init: RequestInit) => {
+      seenInit = init;
+      return Promise.resolve(
+        new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+      );
+    }) as unknown as typeof fetch;
+
+    const outcome = await performHttpAttempt({
+      ...base,
+      url: "https://1.1.1.1/hook",
+      fetchImpl: stubFetch,
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.status).toBe(200);
+    expect(seenInit?.redirect).toBe("manual");
+  });
+});

--- a/test/unit/ssrf-guard.test.ts
+++ b/test/unit/ssrf-guard.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "bun:test";
+import {
+  isBlockedIp,
+  assertPublicWebhookUrl,
+  BlockedUrlError,
+} from "../../src/utils/ssrf-guard.ts";
+
+/**
+ * Unit tests for the webhook SSRF guard (#128). The IP checks and the
+ * scheme / literal-IP-host branches are pure (no DNS), so they're tested
+ * directly. Hostname DNS-resolution is exercised in the integration tier.
+ */
+
+describe("isBlockedIp", () => {
+  test("blocks IPv4 private / loopback / link-local / metadata ranges", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "10.0.0.5",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "0.0.0.0",
+      "100.64.0.1", // CGNAT
+      "224.0.0.1", // multicast
+    ]) {
+      expect(isBlockedIp(ip)).toBe(true);
+    }
+  });
+
+  test("allows normal public IPv4", () => {
+    for (const ip of ["8.8.8.8", "1.1.1.1", "93.184.216.34", "172.32.0.1"]) {
+      expect(isBlockedIp(ip)).toBe(false);
+    }
+  });
+
+  test("blocks IPv6 loopback / ULA / link-local / v4-mapped-private", () => {
+    for (const ip of [
+      "::1",
+      "::",
+      "fc00::1",
+      "fd12:3456::1",
+      "fe80::1",
+      "::ffff:127.0.0.1",
+    ]) {
+      expect(isBlockedIp(ip)).toBe(true);
+    }
+  });
+
+  test("allows public IPv6", () => {
+    expect(isBlockedIp("2606:4700:4700::1111")).toBe(false);
+  });
+
+  test("refuses garbage", () => {
+    expect(isBlockedIp("not-an-ip")).toBe(true);
+    expect(isBlockedIp("999.1.1.1")).toBe(true);
+  });
+});
+
+describe("assertPublicWebhookUrl — scheme & literal-IP checks", () => {
+  test("rejects a literal metadata IP", async () => {
+    await expect(
+      assertPublicWebhookUrl("http://169.254.169.254/latest/meta-data/", true),
+    ).rejects.toBeInstanceOf(BlockedUrlError);
+  });
+
+  test("rejects loopback and private literals", async () => {
+    await expect(
+      assertPublicWebhookUrl("http://127.0.0.1:5432/", true),
+    ).rejects.toThrow();
+    await expect(assertPublicWebhookUrl("https://10.0.0.5/hook", true)).rejects.toThrow();
+    await expect(assertPublicWebhookUrl("http://[::1]/x", true)).rejects.toThrow();
+  });
+
+  test("rejects http when not allowed; message points at the opt-in", async () => {
+    await expect(assertPublicWebhookUrl("http://8.8.8.8/hook", false)).rejects.toThrow(
+      /https/,
+    );
+  });
+
+  test("allows http to a public literal IP when opted in", async () => {
+    await expect(
+      assertPublicWebhookUrl("http://8.8.8.8/hook", true),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects non-http(s) schemes", async () => {
+    await expect(assertPublicWebhookUrl("file:///etc/passwd", true)).rejects.toThrow();
+    await expect(assertPublicWebhookUrl("gopher://127.0.0.1/", true)).rejects.toThrow();
+  });
+
+  test("rejects a non-URL", async () => {
+    await expect(assertPublicWebhookUrl("not a url", true)).rejects.toBeInstanceOf(
+      BlockedUrlError,
+    );
+  });
+
+  test("allows a public https literal IP", async () => {
+    await expect(
+      assertPublicWebhookUrl("https://1.1.1.1/hook", false),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/webhook.service.test.ts
+++ b/test/unit/webhook.service.test.ts
@@ -23,6 +23,26 @@ function chainable<T>(result: T): T {
   return proxy as T;
 }
 
+/**
+ * Own the config mock (complete enough) so a leaked partial stub from an
+ * earlier unit file can't shadow `config.webhookDelivery` — `createWebhook`
+ * reads `config.webhookDelivery.allowInsecureHttp` for the SSRF guard (#128).
+ * Bun's `mock.module` leaks across files; registering ours here (before the
+ * import below) makes it the active one for this file. See the #121 fix.
+ */
+mock.module("../../src/config.ts", () => ({
+  config: {
+    env: "test",
+    database: { url: "postgres://test:test@localhost:5432/test" },
+    server: { port: 3000, host: "0.0.0.0" },
+    mail: { hostname: "localhost" },
+    dashboard: { password: "", sessionSecret: "test-secret" },
+    webhookDelivery: { retentionDays: 30, allowInsecureHttp: false },
+    logLevel: "error",
+    logRedactPii: false,
+  },
+}));
+
 mock.module("../../src/db/index.ts", () => ({
   db: {
     select: mock(() => chainable(selectResult)),

--- a/test/unit/webhook.service.test.ts
+++ b/test/unit/webhook.service.test.ts
@@ -42,7 +42,7 @@ const {
 const baseHook = {
   id: "whk_x",
   apiKeyId: "key_owner",
-  url: "https://hook.example.com",
+  url: "https://93.184.216.34/hook",
   events: ["email.sent"],
   secret: "test-secret-32-bytes-padding-padding",
   isActive: true,
@@ -60,7 +60,7 @@ describe("createWebhook", () => {
   test("returns the inserted row + a 64-char hex secret", async () => {
     insertResult = [baseHook];
     const result = await createWebhook(
-      { url: "https://hook.example.com", events: ["email.sent"] },
+      { url: "https://93.184.216.34/hook", events: ["email.sent"] },
       "key_owner",
     );
     expect(result.webhook.id).toBe("whk_x");


### PR DESCRIPTION
Closes #128. **Critical** — fixes an exfiltrating SSRF.

## Why

Webhook URLs are tenant-supplied and fetched server-side, and the response body is read back through `GET /api/v1/webhooks/deliveries/:id`. Unvalidated, that's a classic **exfiltrating SSRF**: register `http://169.254.169.254/latest/meta-data/…` (or `http://127.0.0.1:5432`, `http://10.0.0.5/…`), subscribe to `email.queued`, send one email — the delivery worker POSTs to the internal address and the response (cloud IMDS creds / internal data) comes straight back via the delivery API. Even an innocent `https://example.com/hook` could 302-redirect into IMDS because redirects were followed.

## Fix

New `src/utils/ssrf-guard.ts` (`assertPublicWebhookUrl`), enforced in **two** places:
- **At create** (`createWebhook` — covers both REST and the dashboard) → `BlockedUrlError` → **HTTP 422 `WEBHOOK_URL_BLOCKED`**.
- **Before every delivery attempt** (`performHttpAttempt`) — DNS can rebind and pre-guard rows exist (TOCTOU), so re-validate each time; a blocked URL is a failed attempt, no fetch.

The guard: scheme must be `https` (or `http` if `WEBHOOK_ALLOW_INSECURE_HTTP=true`); the host is **DNS-resolved** and rejected if **any** address is private/loopback/link-local/ULA/CGNAT/metadata (`127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `100.64/10`, `::1`, `fc00::/7`, `fe80::/10`, v4-mapped, multicast/reserved). Delivery now uses **`redirect: "manual"`**, so a 3xx into an internal address can't bypass the pre-fetch host check (it's counted as a failed delivery).

## Design notes

- `ssrf-guard.ts` is **config-free** (caller passes `allowHttp`) so it unit-tests with no env/mocks.
- New env `WEBHOOK_ALLOW_INSECURE_HTTP` (default `false`).
- **Residual** (documented in THREAT_MODEL): resolve-then-fetch leaves a sub-second DNS-rebind window; an egress firewall/proxy is the belt-and-suspenders control for hostile multi-tenant use.

## Tests

- **Unit** (`ssrf-guard.test.ts`, 12): v4/v6 range checks incl. v4-mapped & garbage; scheme rules; literal-IP hosts; non-URL.
- **Integration** (`webhook-ssrf.integration.test.ts`, 5): create rejects metadata/private/loopback (nothing stored) + accepts public https; delivery does **not** fetch a blocked URL and passes `redirect:'manual'` for allowed ones.
- Updated the existing webhook integration tests to use public literal IPs (the delivery guard now DNS-resolves every attempt, so fake `hook.example.com` hosts no longer resolve).

All green: 424 unit+e2e, 126 integration, tsc, eslint, knip (baseline only).

## Docs

`CHANGELOG.md`, `THREAT_MODEL.md` (webhook SSRF mitigation + residual), `docs/webhooks.md` (URL requirements), `docs/api.md` (422 code), `.env.example`.