### PR TITLE
chore: bump Bun 1.3.10 → 1.3.14 (Dockerfile + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Cache Bun dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Run bun install to regenerate lockfile
         # `--ignore-scripts` matches the Dockerfile's flag — no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Schema:** adds `api_keys.is_admin boolean NOT NULL DEFAULT false` (#130, migration `0011`). **Existing keys are backfilled to `true`** (admin) to preserve pre-#130 behaviour — after deploying, demote any keys you hand to apps/developers from the dashboard. Run `bun run db:migrate` (or rebuild via `docker compose up -d --build`).
 - **Breaking (API):** calling `/api/v1/api-keys`, `/api/v1/domains`, or `/api/v1/inbound` with a **restricted** key now returns `403 ADMIN_REQUIRED` (previously any valid key worked). Existing keys are unaffected (they migrate to admin); only newly-created restricted keys are gated. The dashboard is unaffected (operator session).
+- **Bump Bun 1.3.10 → 1.3.14** (patch) — pinned in the `Dockerfile` (all stages) and the CI workflows (`ci.yml`, `dependabot-lockfile.yml`). Full suite green on 1.3.14. Self-hosters: `docker compose up -d --build` picks up the new base image; run `bun upgrade` locally to match.
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 # ───────────────────────────────────────────────────────
 
 # ── Stage 1: Install all dependencies (incl. dev) ──
-FROM oven/bun:1.3.10 AS install
+FROM oven/bun:1.3.14 AS install
 
 WORKDIR /app
 
@@ -45,7 +45,7 @@ RUN bun install --frozen-lockfile --ignore-scripts
 # Separate stage so the run image gets node_modules without dev deps.
 # Without this stage the runtime carries drizzle-kit + esbuild, whose
 # bundled Go binaries pull ~36 (false-positive) CVEs into Trivy.
-FROM oven/bun:1.3.10 AS prod-deps
+FROM oven/bun:1.3.14 AS prod-deps
 
 WORKDIR /app
 
@@ -54,7 +54,7 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --ignore-scripts --production
 
 # ── Stage 3: Run ──
-FROM oven/bun:1.3.10 AS run
+FROM oven/bun:1.3.14 AS run
 
 # Apply latest Debian security patches. The base image rebuilds on a
 # cadence, but new Debian CVE patches between rebuilds are exactly what


### PR DESCRIPTION
Patch bump of the pinned Bun runtime.

## Changes

- **Dockerfile** — all three stages (`install`, `prod-deps`, `run`): `oven/bun:1.3.10` → `oven/bun:1.3.14`.
- **CI** — `bun-version: 1.3.10` → `1.3.14` in `.github/workflows/ci.yml` and `.github/workflows/dependabot-lockfile.yml`.
- `CHANGELOG.md`.

## Verify

Ran the whole suite on Bun 1.3.14 locally: `tsc --noEmit`, `eslint`, **424 unit+e2e**, **126 integration** — all green. It's a patch bump within the 1.3 line, so no behavior changes expected.

## For self-hosters

`docker compose up -d --build` picks up the new base image; run `bun upgrade` locally to match.